### PR TITLE
Ensure payload has size expected by C client

### DIFF
--- a/src/core/com/cosylab/epics/caj/impl/DBREncoder.java
+++ b/src/core/com/cosylab/epics/caj/impl/DBREncoder.java
@@ -117,6 +117,10 @@ public class DBREncoder {
 	 */
 	private static int calculateValuePayloadSize(int dataCount, Object value, DBRType dataType) 
 	{
+		// Even if the count is zero, the payload must contain at least one element.
+		if (dataCount <= 0) {
+			dataCount = 1;
+		}
 		if (dataType.isDOUBLE())
 		{
 			return dataCount * 8;
@@ -127,16 +131,7 @@ public class DBREncoder {
 		}
 		else if (dataType.isSTRING())
 		{
-			if (dataCount == 1)
-			{
-				String str = ((String[])value)[0];
-				if (str != null)
-					return str.length() + 1;
-				else
-					return 1;
-			}
-			else
-			    return dataCount * CAConstants.MAX_STRING_SIZE;
+			return dataCount * CAConstants.MAX_STRING_SIZE;
 		}
 		else if (dataType.isSHORT())
 		{
@@ -179,61 +174,89 @@ public class DBREncoder {
 		
 		if (dataType.isDOUBLE())
 		{
+			if (count <= 0)
+			{
+				// Even if the array is empty, there has to be at least one element in the payload.
+				payloadBuffer.putDouble(0.0);
+			}
 			double[] array = (double[])value;
 			for (int i = 0; i < count; i++)
 				payloadBuffer.putDouble(array[i]);
 		}
 		else if (dataType.isINT())
 		{
+			if (count <= 0)
+			{
+				// Even if the array is empty, there has to be at least one element in the payload.
+				payloadBuffer.putInt(0);
+			}
 			int[] array = (int[])value;
 			for (int i = 0; i < count; i++)
 				payloadBuffer.putInt(array[i]);
 		}
 		else if (dataType.isSTRING())
 		{
-			String[] array = (String[])value;
-			
-			if (count == 1) {
-				if (array.length > 0 && array[0] != null)
-					payloadBuffer.put(array[0].getBytes());
-			    payloadBuffer.put((byte)0);
-			}
-			else 
+			if (count <= 0)
 			{
-				for (int i = 0; i < count; i++)
-				{
-				    // limit string size, leave one byte for termination
-				    int pos = payloadBuffer.position();
-				    if (array[i] != null)
-				    {
+				// Even if the array is empty, there has to be at least one element in the payload.
+			    int pos = payloadBuffer.position();
+			    payloadBuffer.put((byte)0);
+				payloadBuffer.position(pos + CAConstants.MAX_STRING_SIZE);
+			}
+			String[] array = (String[])value;
+			for (int i = 0; i < count; i++)
+			{
+			    // limit string size, leave one byte for termination
+			    int pos = payloadBuffer.position();
+			    if (array[i] != null)
+			    {
 				    	int bytesToWrite = Math.min(array[i].length(), CAConstants.MAX_STRING_SIZE - 1); 
 				    	payloadBuffer.put(array[i].getBytes(), 0, bytesToWrite);
-				    }
-				    payloadBuffer.put((byte)0);
-					payloadBuffer.position(pos + CAConstants.MAX_STRING_SIZE);
-				}
+			    }
+			    payloadBuffer.put((byte)0);
+				payloadBuffer.position(pos + CAConstants.MAX_STRING_SIZE);
 			}
 		}
 		else if (dataType.isSHORT())
 		{
+			if (count <= 0)
+			{
+				// Even if the array is empty, there has to be at least one element in the payload.
+				payloadBuffer.putShort((short)0);
+			}
 			short[] array = (short[])value;
 			for (int i = 0; i < count; i++)
 				payloadBuffer.putShort(array[i]);
 		}
 		else if (dataType.isFLOAT())
 		{
+			if (count <= 0)
+			{
+				// Even if the array is empty, there has to be at least one element in the payload.
+				payloadBuffer.putFloat(0.0f);
+			}
 			float[] array = (float[])value;
 			for (int i = 0; i < count; i++)
 				payloadBuffer.putFloat(array[i]);
 		}
 		else if (dataType.isENUM())
 		{
+			if (count <= 0)
+			{
+				// Even if the array is empty, there has to be at least one element in the payload.
+				payloadBuffer.putShort((short)0);
+			}
 			short[] array = (short[])value;
 			for (int i = 0; i < count; i++)
 				payloadBuffer.putShort(array[i]);
 		}
 		else if (dataType.isBYTE())
 		{
+			if (count <= 0)
+			{
+				// Even if the array is empty, there has to be at least one element in the payload.
+				payloadBuffer.put((byte)0);
+			}
 			byte[] array = (byte[])value;
 			for (int i = 0; i < count; i++)
 				payloadBuffer.put(array[i]);
@@ -241,6 +264,11 @@ public class DBREncoder {
 		else if (dataType == DBRType.PUT_ACKT ||
 				 dataType == DBRType.PUT_ACKS)
 		{
+			if (count <= 0)
+			{
+				// Even if the array is empty, there has to be at least one element in the payload.
+				payloadBuffer.putShort((short)0);
+			}
 			short[] array = (short[])value;
 			for (int i = 0; i < count; i++)
 				payloadBuffer.putShort(array[i]);


### PR DESCRIPTION
The C client does not validate the payload size indicated by a CA server when copying from the receive buffer into the DBR data structure.

This means that when a server sends a payload that is smaller than expected for the data-type and count, the client library reads beyond the receive buffer limits, potentially reading from uninitialized or sensitive memory and potentially resulting in a segmention fault.

The DBREncoder class had two bugs that could cause this kind of behavior when a C client connects to a server using the CAJ library:

The first problem was that for a count of zero, no elements were sent, but the client expects at least one element to be present in the payload, even if the count is zero and thus this element is never used.

The second problem was that for an empty string, only one byte was sent, but the client expected 40 bytes (EPICS string size).

This patch fixed both problems by filling the payload with null bytes in these cases.