### PR TITLE
Make max and min search periods configurable.

### DIFF
--- a/src/core/JCALibrary.properties
+++ b/src/core/JCALibrary.properties
@@ -1,11 +1,12 @@
 #                    Default JCALibrary properties.
 
-com.cosylab.epics.caj.CAJContext.logger              = com.cosylab.epics.caj.CAJContext
-com.cosylab.epics.caj.CAJContext.addr_list           =
-com.cosylab.epics.caj.CAJContext.auto_addr_list      = true
-com.cosylab.epics.caj.CAJContext.connection_timeout  = 30.0
-com.cosylab.epics.caj.CAJContext.beacon_period       = 15.0
-com.cosylab.epics.caj.CAJContext.repeater_port       = 5065
-com.cosylab.epics.caj.CAJContext.server_port         = 5064
-com.cosylab.epics.caj.CAJContext.max_array_bytes     = 16384
+com.cosylab.epics.caj.CAJContext.logger                 = com.cosylab.epics.caj.CAJContext
+com.cosylab.epics.caj.CAJContext.addr_list              =
+com.cosylab.epics.caj.CAJContext.auto_addr_list         = true
+com.cosylab.epics.caj.CAJContext.connection_timeout     = 30.0
+com.cosylab.epics.caj.CAJContext.beacon_period          = 15.0
+com.cosylab.epics.caj.CAJContext.repeater_port          = 5065
+com.cosylab.epics.caj.CAJContext.server_port            = 5064
+com.cosylab.epics.caj.CAJContext.max_array_bytes        = 16384
+com.cosylab.epics.caj.CAJContext.max_search_interval_ms = 300000
 com.cosylab.epics.caj.impl.reactor.lf.LeaderFollowersThreadPool.thread_pool_size = 5

--- a/src/core/JCALibrary.properties
+++ b/src/core/JCALibrary.properties
@@ -1,12 +1,12 @@
 #                    Default JCALibrary properties.
 
-com.cosylab.epics.caj.CAJContext.logger                 = com.cosylab.epics.caj.CAJContext
-com.cosylab.epics.caj.CAJContext.addr_list              =
-com.cosylab.epics.caj.CAJContext.auto_addr_list         = true
-com.cosylab.epics.caj.CAJContext.connection_timeout     = 30.0
-com.cosylab.epics.caj.CAJContext.beacon_period          = 15.0
-com.cosylab.epics.caj.CAJContext.repeater_port          = 5065
-com.cosylab.epics.caj.CAJContext.server_port            = 5064
-com.cosylab.epics.caj.CAJContext.max_array_bytes        = 16384
-com.cosylab.epics.caj.CAJContext.max_search_interval_ms = 300000
+com.cosylab.epics.caj.CAJContext.logger              = com.cosylab.epics.caj.CAJContext
+com.cosylab.epics.caj.CAJContext.addr_list           =
+com.cosylab.epics.caj.CAJContext.auto_addr_list      = true
+com.cosylab.epics.caj.CAJContext.connection_timeout  = 30.0
+com.cosylab.epics.caj.CAJContext.beacon_period       = 15.0
+com.cosylab.epics.caj.CAJContext.repeater_port       = 5065
+com.cosylab.epics.caj.CAJContext.server_port         = 5064
+com.cosylab.epics.caj.CAJContext.max_array_bytes     = 16384
+com.cosylab.epics.caj.CAJContext.max_search_interval = 300
 com.cosylab.epics.caj.impl.reactor.lf.LeaderFollowersThreadPool.thread_pool_size = 5

--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -179,9 +179,9 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	protected int maxArrayBytes = 16384;
 
 	/**
-	 * Maximum interval between CA search broadcasts. Default is 5 minutes.
+	 * Maximum interval in seconds between CA search broadcasts. Default is 5 minutes.
 	 */
-	protected int maxSearchIntervalMs = 1000 * 60 * 5;
+	protected float maxSearchInterval = (float) 60.0 * 5;
 
 	/**
 	 * List of context message listeners.
@@ -442,7 +442,7 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			if (tmp != null) maxArrayBytes = Integer.parseInt(tmp);
 
 			tmp = System.getenv("EPICS_CA_MAX_SEARCH_PERIOD");
-			if (tmp != null) maxSearchIntervalMs = Integer.parseInt(tmp);
+			if (tmp != null) maxSearchInterval = Float.parseFloat(tmp);
 		}
 		else
 		{
@@ -456,7 +456,7 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			repeaterPort = jcaLibrary.getPropertyAsInt(contextClassName + ".repeater_port", repeaterPort);
 			serverPort = jcaLibrary.getPropertyAsInt(contextClassName + ".server_port", serverPort);
 			maxArrayBytes = jcaLibrary.getPropertyAsInt(contextClassName + ".max_array_bytes", maxArrayBytes);
-			maxSearchIntervalMs = jcaLibrary.getPropertyAsInt(contextClassName + ".max_search_interval_ms", maxSearchIntervalMs);
+			maxSearchInterval = jcaLibrary.getPropertyAsFloat(contextClassName + ".max_search_interval", maxSearchInterval);
 			eventDispatcherClassName = jcaLibrary.getProperty(contextClassName + ".event_dispatcher");
 	
 			// load CAJ specific configuration (overrides default)
@@ -468,7 +468,7 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			repeaterPort = jcaLibrary.getPropertyAsInt(thisClassName + ".repeater_port", repeaterPort);
 			serverPort = jcaLibrary.getPropertyAsInt(thisClassName + ".server_port", serverPort);
 			maxArrayBytes = jcaLibrary.getPropertyAsInt(thisClassName + ".max_array_bytes", maxArrayBytes);
-			maxSearchIntervalMs = jcaLibrary.getPropertyAsInt(thisClassName + ".max_search_interval_ms", maxSearchIntervalMs);
+			maxSearchInterval = jcaLibrary.getPropertyAsFloat(thisClassName + ".max_search_interval", maxSearchInterval);
 	    }
 			
 		eventDispatcherClassName = jcaLibrary.getProperty(thisClassName + ".event_dispatcher", eventDispatcherClassName);
@@ -542,9 +542,9 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 
 			// max. search interval
 			try {
-				maxSearchIntervalMs = configuration.getChild("max_search_interval_ms", false).getValueAsInteger();
+				maxSearchInterval = configuration.getChild("max_search_interval", false).getValueAsFloat();
 			} catch(Exception ex) {
-				maxSearchIntervalMs = configuration.getAttributeAsInteger("max_search_interval_ms", maxSearchIntervalMs);
+				maxSearchInterval = configuration.getAttributeAsFloat("max_search_interval", maxSearchInterval);
 			}
 
 			// event dispathcer
@@ -1279,7 +1279,7 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 		out.println("REPEATER_PORT : " + repeaterPort);
 		out.println("SERVER_PORT : " + serverPort);
 		out.println("MAX_ARRAY_BYTES : " + maxArrayBytes);
-		out.println("MAX_SEARCH_INTERVAL_MS : " + maxSearchIntervalMs);
+		out.println("MAX_SEARCH_INTERVAL : " + maxSearchInterval);
 		out.println("EVENT_DISPATCHER: " + eventDispatcher);
 		out.print("STATE : ");
 		switch (state)
@@ -1390,7 +1390,7 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	 * Get max. search interval
 	 * @return max. search interval
 	 */
-	public int getMaxSearchIntervalMs() { return maxSearchIntervalMs; }
+	public float getMaxSearchInterval() { return maxSearchInterval; }
 
 	/**
 	 * Get event dispatcher.

--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -409,43 +409,43 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 
 		String eventDispatcherClassName = null;
 		final String thisClassName = this.getClass().getName();
-	    if (Boolean.getBoolean("jca.use_env"))
-	    {
-	    	// Context default configuration
-	    	eventDispatcherClassName = jcaLibrary.getProperty( gov.aps.jca.Context.class.getName()+".event_dispatcher", eventDispatcherClassName );
+		if (Boolean.getBoolean("jca.use_env"))
+		{
+			// Context default configuration
+			eventDispatcherClassName = jcaLibrary.getProperty( gov.aps.jca.Context.class.getName()+".event_dispatcher", eventDispatcherClassName );
 
-	        String tmp = System.getenv("EPICS_CA_ADDR_LIST");
-	        if (tmp != null) addressList = tmp;
-	        
-	    	tmp = System.getenv("EPICS_CA_AUTO_ADDR_LIST");
-	    	if (tmp != null)
-	    		autoAddressList = !tmp.equalsIgnoreCase("NO"); 
-	    	else
-	    		autoAddressList = true;
+			String tmp = System.getenv("EPICS_CA_ADDR_LIST");
+			if (tmp != null) addressList = tmp;
 
-	        tmp = System.getenv("EPICS_CA_NAME_SERVERS");
-	        if (tmp != null) nameServersList = tmp;
-	    	
-	    	tmp = System.getenv("EPICS_CA_CONN_TMO");
-	    	if (tmp != null) connectionTimeout = Float.parseFloat(tmp);
-	    	
-	    	tmp = System.getenv("EPICS_CA_BEACON_PERIOD");
-	       	if (tmp != null) beaconPeriod = Float.parseFloat(tmp);
-	           	
-	    	tmp = System.getenv("EPICS_CA_REPEATER_PORT");
-	    	if (tmp != null) repeaterPort = Integer.parseInt(tmp);
-	    	
-	    	tmp = System.getenv("EPICS_CA_SERVER_PORT");
-	    	if (tmp != null) serverPort = Integer.parseInt(tmp);
+			tmp = System.getenv("EPICS_CA_AUTO_ADDR_LIST");
+			if (tmp != null)
+				autoAddressList = !tmp.equalsIgnoreCase("NO");
+			else
+				autoAddressList = true;
 
-	    	tmp = System.getenv("EPICS_CA_MAX_ARRAY_BYTES");
-	    	if (tmp != null) maxArrayBytes = Integer.parseInt(tmp);
+			tmp = System.getenv("EPICS_CA_NAME_SERVERS");
+			if (tmp != null) nameServersList = tmp;
+
+			tmp = System.getenv("EPICS_CA_CONN_TMO");
+			if (tmp != null) connectionTimeout = Float.parseFloat(tmp);
+
+			tmp = System.getenv("EPICS_CA_BEACON_PERIOD");
+			if (tmp != null) beaconPeriod = Float.parseFloat(tmp);
+
+			tmp = System.getenv("EPICS_CA_REPEATER_PORT");
+			if (tmp != null) repeaterPort = Integer.parseInt(tmp);
+
+			tmp = System.getenv("EPICS_CA_SERVER_PORT");
+			if (tmp != null) serverPort = Integer.parseInt(tmp);
+
+			tmp = System.getenv("EPICS_CA_MAX_ARRAY_BYTES");
+			if (tmp != null) maxArrayBytes = Integer.parseInt(tmp);
 
 			tmp = System.getenv("EPICS_CA_MAX_SEARCH_PERIOD");
 			if (tmp != null) maxSearchIntervalMs = Integer.parseInt(tmp);
-	    }
-	    else
-	    {
+		}
+		else
+		{
 			// load default Context configuration
 			final String contextClassName = Context.class.getName();
 			addressList = jcaLibrary.getProperty(contextClassName + ".addr_list", addressList);

--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -179,6 +179,16 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	protected int maxArrayBytes = 16384;
 
 	/**
+	 * Minimum interval between CA search broadcasts.
+	 */
+	protected int minSearchIntervalMs = 100;
+
+	/**
+	 * Maximum interval between CA search broadcasts.
+	 */
+	protected int maxSearchIntervalMs = 30000;
+
+	/**
 	 * List of context message listeners.
 	 */
 	// TODO consider using weak references
@@ -435,6 +445,12 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 
 	    	tmp = System.getenv("EPICS_CA_MAX_ARRAY_BYTES");
 	    	if (tmp != null) maxArrayBytes = Integer.parseInt(tmp);
+
+			tmp = System.getenv("EPICS_CA_MIN_SEARCH_PERIOD");
+			if (tmp != null) minSearchIntervalMs = Integer.parseInt(tmp);
+
+			tmp = System.getenv("EPICS_CA_MAX_SEARCH_PERIOD");
+			if (tmp != null) maxSearchIntervalMs = Integer.parseInt(tmp);
 	    }
 	    else
 	    {
@@ -448,6 +464,8 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			repeaterPort = jcaLibrary.getPropertyAsInt(contextClassName + ".repeater_port", repeaterPort);
 			serverPort = jcaLibrary.getPropertyAsInt(contextClassName + ".server_port", serverPort);
 			maxArrayBytes = jcaLibrary.getPropertyAsInt(contextClassName + ".max_array_bytes", maxArrayBytes);
+			minSearchIntervalMs = jcaLibrary.getPropertyAsInt(contextClassName + ".min_search_interval_ms", minSearchIntervalMs);
+			maxSearchIntervalMs = jcaLibrary.getPropertyAsInt(contextClassName + ".max_search_interval_ms", maxSearchIntervalMs);
 			eventDispatcherClassName = jcaLibrary.getProperty(contextClassName + ".event_dispatcher");
 	
 			// load CAJ specific configuration (overrides default)
@@ -459,6 +477,8 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			repeaterPort = jcaLibrary.getPropertyAsInt(thisClassName + ".repeater_port", repeaterPort);
 			serverPort = jcaLibrary.getPropertyAsInt(thisClassName + ".server_port", serverPort);
 			maxArrayBytes = jcaLibrary.getPropertyAsInt(thisClassName + ".max_array_bytes", maxArrayBytes);
+			minSearchIntervalMs = jcaLibrary.getPropertyAsInt(thisClassName + ".min_search_interval_ms", minSearchIntervalMs);
+			maxSearchIntervalMs = jcaLibrary.getPropertyAsInt(thisClassName + ".max_search_interval_ms", maxSearchIntervalMs);
 	    }
 			
 		eventDispatcherClassName = jcaLibrary.getProperty(thisClassName + ".event_dispatcher", eventDispatcherClassName);
@@ -528,6 +548,19 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 				maxArrayBytes = configuration.getChild("max_array_bytes", false).getValueAsInteger();
 			} catch(Exception ex) {
 				maxArrayBytes = configuration.getAttributeAsInteger("max_array_bytes", maxArrayBytes);
+			}
+
+			// min. search interval
+			try {
+				minSearchIntervalMs = configuration.getChild("min_search_interval_ms", false).getValueAsInteger();
+			} catch(Exception ex) {
+				minSearchIntervalMs = configuration.getAttributeAsInteger("min_search_interval_ms", minSearchIntervalMs);
+			}
+			// max. search interval
+			try {
+				maxSearchIntervalMs = configuration.getChild("max_search_interval_ms", false).getValueAsInteger();
+			} catch(Exception ex) {
+				maxSearchIntervalMs = configuration.getAttributeAsInteger("max_search_interval_ms", maxSearchIntervalMs);
 			}
 
 			// event dispathcer
@@ -1262,6 +1295,8 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 		out.println("REPEATER_PORT : " + repeaterPort);
 		out.println("SERVER_PORT : " + serverPort);
 		out.println("MAX_ARRAY_BYTES : " + maxArrayBytes);
+		out.println("MIN_SEARCH_INTERVAL_MS : " + minSearchIntervalMs);
+		out.println("MAX_SEARCH_INTERVAL_MS : " + maxSearchIntervalMs);
 		out.println("EVENT_DISPATCHER: " + eventDispatcher);
 		out.print("STATE : ");
 		switch (state)
@@ -1367,6 +1402,18 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	public int getBroadcastPort() {
 		return getServerPort();
 	}
+
+	/**
+	 * Get min. search interval
+	 * @return min. search interval
+	 */
+	public int getMinSearchIntervalMs() { return minSearchIntervalMs; }
+
+	/**
+	 * Get max. search interval
+	 * @return max. search interval
+	 */
+	public int getMaxSearchIntervalMs() { return maxSearchIntervalMs; }
 
 	/**
 	 * Get event dispatcher.

--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -179,9 +179,9 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	protected int maxArrayBytes = 16384;
 
 	/**
-	 * Maximum interval between CA search broadcasts.
+	 * Maximum interval between CA search broadcasts. Default is 5 minutes.
 	 */
-	protected int maxSearchIntervalMs = 30000;
+	protected int maxSearchIntervalMs = 1000 * 60 * 5;
 
 	/**
 	 * List of context message listeners.

--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -179,11 +179,6 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	protected int maxArrayBytes = 16384;
 
 	/**
-	 * Minimum interval between CA search broadcasts.
-	 */
-	protected int minSearchIntervalMs = 100;
-
-	/**
 	 * Maximum interval between CA search broadcasts.
 	 */
 	protected int maxSearchIntervalMs = 30000;
@@ -446,9 +441,6 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	    	tmp = System.getenv("EPICS_CA_MAX_ARRAY_BYTES");
 	    	if (tmp != null) maxArrayBytes = Integer.parseInt(tmp);
 
-			tmp = System.getenv("EPICS_CA_MIN_SEARCH_PERIOD");
-			if (tmp != null) minSearchIntervalMs = Integer.parseInt(tmp);
-
 			tmp = System.getenv("EPICS_CA_MAX_SEARCH_PERIOD");
 			if (tmp != null) maxSearchIntervalMs = Integer.parseInt(tmp);
 	    }
@@ -464,7 +456,6 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			repeaterPort = jcaLibrary.getPropertyAsInt(contextClassName + ".repeater_port", repeaterPort);
 			serverPort = jcaLibrary.getPropertyAsInt(contextClassName + ".server_port", serverPort);
 			maxArrayBytes = jcaLibrary.getPropertyAsInt(contextClassName + ".max_array_bytes", maxArrayBytes);
-			minSearchIntervalMs = jcaLibrary.getPropertyAsInt(contextClassName + ".min_search_interval_ms", minSearchIntervalMs);
 			maxSearchIntervalMs = jcaLibrary.getPropertyAsInt(contextClassName + ".max_search_interval_ms", maxSearchIntervalMs);
 			eventDispatcherClassName = jcaLibrary.getProperty(contextClassName + ".event_dispatcher");
 	
@@ -477,7 +468,6 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			repeaterPort = jcaLibrary.getPropertyAsInt(thisClassName + ".repeater_port", repeaterPort);
 			serverPort = jcaLibrary.getPropertyAsInt(thisClassName + ".server_port", serverPort);
 			maxArrayBytes = jcaLibrary.getPropertyAsInt(thisClassName + ".max_array_bytes", maxArrayBytes);
-			minSearchIntervalMs = jcaLibrary.getPropertyAsInt(thisClassName + ".min_search_interval_ms", minSearchIntervalMs);
 			maxSearchIntervalMs = jcaLibrary.getPropertyAsInt(thisClassName + ".max_search_interval_ms", maxSearchIntervalMs);
 	    }
 			
@@ -550,12 +540,6 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 				maxArrayBytes = configuration.getAttributeAsInteger("max_array_bytes", maxArrayBytes);
 			}
 
-			// min. search interval
-			try {
-				minSearchIntervalMs = configuration.getChild("min_search_interval_ms", false).getValueAsInteger();
-			} catch(Exception ex) {
-				minSearchIntervalMs = configuration.getAttributeAsInteger("min_search_interval_ms", minSearchIntervalMs);
-			}
 			// max. search interval
 			try {
 				maxSearchIntervalMs = configuration.getChild("max_search_interval_ms", false).getValueAsInteger();
@@ -1295,7 +1279,6 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 		out.println("REPEATER_PORT : " + repeaterPort);
 		out.println("SERVER_PORT : " + serverPort);
 		out.println("MAX_ARRAY_BYTES : " + maxArrayBytes);
-		out.println("MIN_SEARCH_INTERVAL_MS : " + minSearchIntervalMs);
 		out.println("MAX_SEARCH_INTERVAL_MS : " + maxSearchIntervalMs);
 		out.println("EVENT_DISPATCHER: " + eventDispatcher);
 		out.print("STATE : ");
@@ -1402,12 +1385,6 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	public int getBroadcastPort() {
 		return getServerPort();
 	}
-
-	/**
-	 * Get min. search interval
-	 * @return min. search interval
-	 */
-	public int getMinSearchIntervalMs() { return minSearchIntervalMs; }
 
 	/**
 	 * Get max. search interval

--- a/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
+++ b/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
@@ -34,8 +34,6 @@ public class ChannelSearchManager {
 	 */
 	private final int intervalMultiplier;
 
-	private static final int MIN_SEND_INTERVAL_MS_DEFAULT = 100;
-	private static final int MAX_SEND_INTERVAL_MS_DEFAULT = 30000;
 	private static final int INTERVAL_MULTIPLIER_DEFAULT = 2;
 	
 	private static final int MESSAGE_COALESCENCE_TIME_MS = 3;
@@ -193,8 +191,8 @@ public class ChannelSearchManager {
 	{
 		this.context = context;
 
-		minSendInterval = MIN_SEND_INTERVAL_MS_DEFAULT;
-		maxSendInterval = MAX_SEND_INTERVAL_MS_DEFAULT;
+		minSendInterval = context.getMinSearchIntervalMs();
+		maxSendInterval = context.getMaxSearchIntervalMs();
 		intervalMultiplier = INTERVAL_MULTIPLIER_DEFAULT;
 
 		// create and initialize send buffer

--- a/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
+++ b/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
@@ -193,7 +193,8 @@ public class ChannelSearchManager {
 		this.context = context;
 
 		minSendInterval = MIN_SEND_INTERVAL_MS_DEFAULT;
-		maxSendInterval = context.getMaxSearchIntervalMs();
+		// Convert from seconds to milliseconds.
+		maxSendInterval = (long) (context.getMaxSearchInterval() * 1000);
 		intervalMultiplier = INTERVAL_MULTIPLIER_DEFAULT;
 
 		// create and initialize send buffer

--- a/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
+++ b/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
@@ -34,6 +34,7 @@ public class ChannelSearchManager {
 	 */
 	private final int intervalMultiplier;
 
+	private static final int MIN_SEND_INTERVAL_MS_DEFAULT = 100;
 	private static final int INTERVAL_MULTIPLIER_DEFAULT = 2;
 	
 	private static final int MESSAGE_COALESCENCE_TIME_MS = 3;
@@ -191,7 +192,7 @@ public class ChannelSearchManager {
 	{
 		this.context = context;
 
-		minSendInterval = context.getMinSearchIntervalMs();
+		minSendInterval = MIN_SEND_INTERVAL_MS_DEFAULT;
 		maxSendInterval = context.getMaxSearchIntervalMs();
 		intervalMultiplier = INTERVAL_MULTIPLIER_DEFAULT;
 

--- a/src/core/gov/aps/jca/JCALibrary.properties
+++ b/src/core/gov/aps/jca/JCALibrary.properties
@@ -1,11 +1,12 @@
 #                    Default JCALibrary properties.
 
-com.cosylab.epics.caj.CAJContext.logger              = com.cosylab.epics.caj.CAJContext
-com.cosylab.epics.caj.CAJContext.addr_list           =
-com.cosylab.epics.caj.CAJContext.auto_addr_list      = true
-com.cosylab.epics.caj.CAJContext.connection_timeout  = 30.0
-com.cosylab.epics.caj.CAJContext.beacon_period       = 15.0
-com.cosylab.epics.caj.CAJContext.repeater_port       = 5065
-com.cosylab.epics.caj.CAJContext.server_port         = 5064
-com.cosylab.epics.caj.CAJContext.max_array_bytes     = 16384
+com.cosylab.epics.caj.CAJContext.logger                 = com.cosylab.epics.caj.CAJContext
+com.cosylab.epics.caj.CAJContext.addr_list              =
+com.cosylab.epics.caj.CAJContext.auto_addr_list         = true
+com.cosylab.epics.caj.CAJContext.connection_timeout     = 30.0
+com.cosylab.epics.caj.CAJContext.beacon_period          = 15.0
+com.cosylab.epics.caj.CAJContext.repeater_port          = 5065
+com.cosylab.epics.caj.CAJContext.server_port            = 5064
+com.cosylab.epics.caj.CAJContext.max_array_bytes        = 16384
+com.cosylab.epics.caj.CAJContext.max_search_interval_ms = 300000
 com.cosylab.epics.caj.impl.reactor.lf.LeaderFollowersThreadPool.thread_pool_size = 5

--- a/src/core/gov/aps/jca/JCALibrary.properties
+++ b/src/core/gov/aps/jca/JCALibrary.properties
@@ -1,12 +1,12 @@
 #                    Default JCALibrary properties.
 
-com.cosylab.epics.caj.CAJContext.logger                 = com.cosylab.epics.caj.CAJContext
-com.cosylab.epics.caj.CAJContext.addr_list              =
-com.cosylab.epics.caj.CAJContext.auto_addr_list         = true
-com.cosylab.epics.caj.CAJContext.connection_timeout     = 30.0
-com.cosylab.epics.caj.CAJContext.beacon_period          = 15.0
-com.cosylab.epics.caj.CAJContext.repeater_port          = 5065
-com.cosylab.epics.caj.CAJContext.server_port            = 5064
-com.cosylab.epics.caj.CAJContext.max_array_bytes        = 16384
-com.cosylab.epics.caj.CAJContext.max_search_interval_ms = 300000
+com.cosylab.epics.caj.CAJContext.logger              = com.cosylab.epics.caj.CAJContext
+com.cosylab.epics.caj.CAJContext.addr_list           =
+com.cosylab.epics.caj.CAJContext.auto_addr_list      = true
+com.cosylab.epics.caj.CAJContext.connection_timeout  = 30.0
+com.cosylab.epics.caj.CAJContext.beacon_period       = 15.0
+com.cosylab.epics.caj.CAJContext.repeater_port       = 5065
+com.cosylab.epics.caj.CAJContext.server_port         = 5064
+com.cosylab.epics.caj.CAJContext.max_array_bytes     = 16384
+com.cosylab.epics.caj.CAJContext.max_search_interval = 300
 com.cosylab.epics.caj.impl.reactor.lf.LeaderFollowersThreadPool.thread_pool_size = 5

--- a/test/com/cosylab/epics/caj/cas/test/JCALibrary.properties
+++ b/test/com/cosylab/epics/caj/cas/test/JCALibrary.properties
@@ -1,11 +1,12 @@
 #                    Default JCALibrary properties.
 
-com.cosylab.epics.caj.CAJContext.logger              = com.cosylab.epics.caj.CAJContext
-com.cosylab.epics.caj.CAJContext.addr_list           =
-com.cosylab.epics.caj.CAJContext.auto_addr_list      = true
-com.cosylab.epics.caj.CAJContext.connection_timeout  = 30.0
-com.cosylab.epics.caj.CAJContext.beacon_period       = 15.0
-com.cosylab.epics.caj.CAJContext.repeater_port       = 5065
-com.cosylab.epics.caj.CAJContext.server_port         = 5064
-com.cosylab.epics.caj.CAJContext.max_array_bytes     = 16384
+com.cosylab.epics.caj.CAJContext.logger                 = com.cosylab.epics.caj.CAJContext
+com.cosylab.epics.caj.CAJContext.addr_list              =
+com.cosylab.epics.caj.CAJContext.auto_addr_list         = true
+com.cosylab.epics.caj.CAJContext.connection_timeout     = 30.0
+com.cosylab.epics.caj.CAJContext.beacon_period          = 15.0
+com.cosylab.epics.caj.CAJContext.repeater_port          = 5065
+com.cosylab.epics.caj.CAJContext.server_port            = 5064
+com.cosylab.epics.caj.CAJContext.max_array_bytes        = 16384
+com.cosylab.epics.caj.CAJContext.max_search_interval_ms = 300000
 com.cosylab.epics.caj.impl.reactor.lf.LeaderFollowersThreadPool.thread_pool_size = 5

--- a/test/com/cosylab/epics/caj/cas/test/JCALibrary.properties
+++ b/test/com/cosylab/epics/caj/cas/test/JCALibrary.properties
@@ -1,12 +1,12 @@
 #                    Default JCALibrary properties.
 
-com.cosylab.epics.caj.CAJContext.logger                 = com.cosylab.epics.caj.CAJContext
-com.cosylab.epics.caj.CAJContext.addr_list              =
-com.cosylab.epics.caj.CAJContext.auto_addr_list         = true
-com.cosylab.epics.caj.CAJContext.connection_timeout     = 30.0
-com.cosylab.epics.caj.CAJContext.beacon_period          = 15.0
-com.cosylab.epics.caj.CAJContext.repeater_port          = 5065
-com.cosylab.epics.caj.CAJContext.server_port            = 5064
-com.cosylab.epics.caj.CAJContext.max_array_bytes        = 16384
-com.cosylab.epics.caj.CAJContext.max_search_interval_ms = 300000
+com.cosylab.epics.caj.CAJContext.logger              = com.cosylab.epics.caj.CAJContext
+com.cosylab.epics.caj.CAJContext.addr_list           =
+com.cosylab.epics.caj.CAJContext.auto_addr_list      = true
+com.cosylab.epics.caj.CAJContext.connection_timeout  = 30.0
+com.cosylab.epics.caj.CAJContext.beacon_period       = 15.0
+com.cosylab.epics.caj.CAJContext.repeater_port       = 5065
+com.cosylab.epics.caj.CAJContext.server_port         = 5064
+com.cosylab.epics.caj.CAJContext.max_array_bytes     = 16384
+com.cosylab.epics.caj.CAJContext.max_search_interval = 300
 com.cosylab.epics.caj.impl.reactor.lf.LeaderFollowersThreadPool.thread_pool_size = 5


### PR DESCRIPTION
The default max search period for the channel access client in EPICS base
is 300 seconds, and it honours the environment variable
EPICS_CA_MAX_SEARCH_PERIOD. The default for JCA is 30 seconds. This commit
makes that value (and the equivalent min value) configurable either using
the environment variable or the jca properties file.

See #25 - very happy to discuss this if you would like changes.