### PR TITLE
Add source jar manifest headers to allow automatic linking by Eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.2.1</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries> 
+                            <Bundle-Name>${name} Source</Bundle-Name>
+                            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.source</Bundle-SymbolicName>
+                            <Bundle-Version>${project.version}</Bundle-Version>
+                            <Eclipse-SourceBundle>${project.groupId}.${project.artifactId};version="${project.version}"</Eclipse-SourceBundle>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
When jca is materialized from a p2 site these headers (specifically
Eclipse-SourceBundle) will allow the source to be obtained as well. It
can then be automatically linked by Eclipse.