### PR TITLE
Set logging level to ERROR for Maven testing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
                 <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.config.file</name>
+                            <value>test/resources/logging.properties</value>
+                        </property>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <!-- Required add sources to deployment -->

--- a/test/resources/logging.properties
+++ b/test/resources/logging.properties
@@ -1,0 +1,2 @@
+# Low verbosity of logging for Maven tests.
+java.util.logging.ConsoleHandler.level = ERROR


### PR DESCRIPTION
This reduces the size of the output file, which is too large for Travis.
Closes #21.

One could have a debate about how you may get less logging for the tests that failed, but since Travis is not really working at the moment I don't think that's really valid.