### PR TITLE
BroadcastTransport handle failed send()

### DIFF
--- a/src/core/com/cosylab/epics/caj/impl/BroadcastTransport.java
+++ b/src/core/com/cosylab/epics/caj/impl/BroadcastTransport.java
@@ -239,6 +239,7 @@ public class BroadcastTransport implements Transport, ReactorHandler {
 			}
 			catch (Throwable ioex) 
 			{
+				buffer.position(buffer.limit());
 				// TODO what to do here
 				logger.log(Level.WARNING, "Failed to sent a datagram to:" + broadcastAddresses[i], ioex);
 			}


### PR DESCRIPTION
Place buffer in expected state after failed() send().  Otherwise, subsequent iterations of this loop erroneously
send a zero length UDP packet.

Fixes https://github.com/epics-base/jca/issues/45