### PR TITLE
CA client search configuration

### DIFF
--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -162,6 +162,20 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	 * Period in second between two beacon signals.
 	 */
 	protected float beaconPeriod = 15.0f;
+
+	/**
+	 * Factor by which beacon period needs to shrink
+	 * to consider it a 'fast' beacon which suggests
+	 * a CA server restart/reboot.
+	 */
+	protected float beaconSpeedup = 0.8f;
+
+	/**
+	 * Factor by which beacon period needs to grow
+	 * to consider it a slow, delayed beacon which
+	 * suggests a restored network segment.
+	 */
+	protected float beaconSlowdown = 1.25f;
 	
 	/**
 	 * Port number for the repeater to listen to.
@@ -465,6 +479,8 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			nameServersList = jcaLibrary.getProperty(thisClassName + ".name_servers", nameServersList);
 			connectionTimeout = jcaLibrary.getPropertyAsFloat(thisClassName + ".connection_timeout", connectionTimeout);
 			beaconPeriod = jcaLibrary.getPropertyAsFloat(thisClassName + ".beacon_period", beaconPeriod);
+			beaconSpeedup = jcaLibrary.getPropertyAsFloat(thisClassName + ".beacon_speedup", beaconSpeedup);
+			beaconSlowdown = jcaLibrary.getPropertyAsFloat(thisClassName + ".beacon_slowdown", beaconSlowdown);
 			repeaterPort = jcaLibrary.getPropertyAsInt(thisClassName + ".repeater_port", repeaterPort);
 			serverPort = jcaLibrary.getPropertyAsInt(thisClassName + ".server_port", serverPort);
 			maxArrayBytes = jcaLibrary.getPropertyAsInt(thisClassName + ".max_array_bytes", maxArrayBytes);
@@ -1336,6 +1352,30 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	 */
 	public float getBeaconPeriod() {
 		return beaconPeriod;
+	}
+
+	/**
+	 * Get beacon speedup.
+	 *
+	 * Factor by which beacon period needs to shrink
+	 * to consider it a 'fast' beacon which suggests
+	 * a CA server restart/reboot.
+	 * @return beacon speedup factor
+	 */
+	public float getBeaconSpeedup() {
+		return beaconSpeedup;
+	}
+
+	/**
+	 * Get beacon slowdown.
+	 *
+	 * Factor by which beacon period needs to grow
+	 * to consider it a slow, delayed beacon which
+	 * suggests a restored network segment.
+	 * @return beacon speedup factor
+	 */
+	public float getBeaconSlowdown() {
+		return beaconSlowdown;
 	}
 
 	/**

--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -193,6 +193,11 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	protected int maxArrayBytes = 16384;
 
 	/**
+	 * Minimum interval in seconds between CA search broadcasts. Default is 0.1 seconds
+	 */
+	protected float minSearchInterval = (float) 0.1;
+
+	/**
 	 * Maximum interval in seconds between CA search broadcasts. Default is 5 minutes.
 	 */
 	protected float maxSearchInterval = (float) 60.0 * 5;
@@ -484,6 +489,7 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			repeaterPort = jcaLibrary.getPropertyAsInt(thisClassName + ".repeater_port", repeaterPort);
 			serverPort = jcaLibrary.getPropertyAsInt(thisClassName + ".server_port", serverPort);
 			maxArrayBytes = jcaLibrary.getPropertyAsInt(thisClassName + ".max_array_bytes", maxArrayBytes);
+			minSearchInterval = jcaLibrary.getPropertyAsFloat(thisClassName + ".min_search_interval", minSearchInterval);
 			maxSearchInterval = jcaLibrary.getPropertyAsFloat(thisClassName + ".max_search_interval", maxSearchInterval);
 	    }
 			
@@ -1425,6 +1431,12 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 	public int getBroadcastPort() {
 		return getServerPort();
 	}
+
+	/**
+	 * Get min. search interval
+	 * @return min. search interval in seconds
+	 */
+	public float getMinSearchInterval() { return minSearchInterval; }
 
 	/**
 	 * Get max. search interval

--- a/src/core/com/cosylab/epics/caj/impl/BroadcastTransport.java
+++ b/src/core/com/cosylab/epics/caj/impl/BroadcastTransport.java
@@ -22,6 +22,7 @@ import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectionKey;
+import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -363,5 +364,9 @@ public class BroadcastTransport implements Transport, ReactorHandler {
 	 */
 	public DatagramChannel getChannel() {
 		return channel;
+	}
+
+	public String toString() {
+		return "BroadcastTransport" + Arrays.toString(broadcastAddresses);
 	}
 }

--- a/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
+++ b/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
@@ -73,7 +73,7 @@ public class CABeaconHandler  {
 		this.context = context;
 		this.responseFrom = responseFrom;
 
-		context.getLogger().log(Level.WARNING, "CABeaconHandler for " + responseFrom + ": Speedup " + context.getBeaconSpeedup() + ", slowdown " + context.getBeaconSlowdown());
+		context.getLogger().log(Level.FINE, "CABeaconHandler for " + responseFrom + ": Speedup " + context.getBeaconSpeedup() + ", slowdown " + context.getBeaconSlowdown());
 	}
 	
 	/**
@@ -103,7 +103,7 @@ public class CABeaconHandler  {
 		if (lastBeaconTimeStamp == Long.MIN_VALUE)
 		{
 			// new server up...
-			context.getLogger().log(Level.WARNING, "New server beacon " + responseFrom);
+			context.getLogger().log(Level.INFO, "New server beacon " + responseFrom);
 			context.beaconAnomalyNotify();
 			
 			if (remoteTransportRevision >= 10)
@@ -162,7 +162,7 @@ public class CABeaconHandler  {
 			{
 				if (currentPeriod >= (averagePeriod * 3.25))
 				{
-					context.getLogger().log(Level.WARNING, "Restored network segment beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
+					context.getLogger().log(Level.INFO, "Restored network segment beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
 					context.beaconAnomalyNotify();
 
 					// trigger network change on any 3 contiguous missing beacons 
@@ -177,7 +177,7 @@ public class CABeaconHandler  {
 				else
 				{
 					// something might be wrong...
-					context.getLogger().log(Level.WARNING, "Delayed beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
+					context.getLogger().log(Level.INFO, "Delayed beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
 					context.beaconAnomalyNotify();
 				}
 			}
@@ -186,7 +186,7 @@ public class CABeaconHandler  {
 			else if (periodStabilized  &&  currentPeriod <= (averagePeriod * context.getBeaconSpeedup()))
 			{
 				// server restarted...
-				context.getLogger().log(Level.WARNING, "Fast 'reboot' beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
+				context.getLogger().log(Level.INFO, "Fast 'reboot' beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
 				context.beaconAnomalyNotify();
 				
 				networkChange = true;

--- a/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
+++ b/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
@@ -84,7 +84,7 @@ public class CABeaconHandler  {
 	 */
 	public void beaconNotify(short remoteTransportRevision, long timestamp, long sequentalID)
 	{
-		context.getLogger().log(Level.WARNING, "Beacon " + timestamp + " [" + sequentalID + "] from " + responseFrom + " ...");
+		context.getLogger().log(Level.FINE, () -> "Beacon " + timestamp + " [" + sequentalID + "] from " + responseFrom + " ...");
 		boolean networkChanged = updateBeaconPeriod(remoteTransportRevision, timestamp, sequentalID);
 		if (networkChanged)
 			changedTransport();
@@ -211,7 +211,7 @@ public class CABeaconHandler  {
 
 		lastBeaconTimeStamp = timestamp;
 
-		context.getLogger().log(Level.WARNING, "beacon " + responseFrom + " period: " + averagePeriod + (periodStabilized ? " (stable)" : " (not stable)"));
+		context.getLogger().log(Level.FINE, () -> "beacon " + responseFrom + " period: " + averagePeriod + (periodStabilized ? " (stable)" : " (not stable)"));
 		
 		return networkChange;
 	}

--- a/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
+++ b/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
@@ -15,6 +15,7 @@
 package com.cosylab.epics.caj.impl;
 
 import java.net.InetSocketAddress;
+import java.util.logging.Level;
 
 import com.cosylab.epics.caj.CAJContext;
 
@@ -81,6 +82,7 @@ public class CABeaconHandler  {
 	 */
 	public void beaconNotify(short remoteTransportRevision, long timestamp, long sequentalID)
 	{
+		context.getLogger().log(Level.WARNING, "Beacon " + timestamp + " [" + sequentalID + "] from " + responseFrom + " ...");
 		boolean networkChanged = updateBeaconPeriod(remoteTransportRevision, timestamp, sequentalID);
 		if (networkChanged)
 			changedTransport();
@@ -99,6 +101,7 @@ public class CABeaconHandler  {
 		if (lastBeaconTimeStamp == Long.MIN_VALUE)
 		{
 			// new server up...
+			context.getLogger().log(Level.WARNING, "New server beacon " + responseFrom);
 			context.beaconAnomalyNotify();
 			
 			if (remoteTransportRevision >= 10)
@@ -153,6 +156,7 @@ public class CABeaconHandler  {
 			{
 				if (currentPeriod >= (averagePeriod * 3.25))
 				{
+					context.getLogger().log(Level.WARNING, "Restored network segment beacon " + responseFrom);
 					context.beaconAnomalyNotify();
 
 					// trigger network change on any 3 contiguous missing beacons 
@@ -167,6 +171,7 @@ public class CABeaconHandler  {
 				else
 				{
 					// something might be wrong...
+					context.getLogger().log(Level.WARNING, "Delayed beacon " + responseFrom);
 					context.beaconAnomalyNotify();
 				}
 			}
@@ -175,6 +180,7 @@ public class CABeaconHandler  {
 			else if (currentPeriod <= (averagePeriod * 0.8))
 			{
 				// server restarted...
+                                context.getLogger().log(Level.WARNING, "Fast 'reboot' beacon " + responseFrom);
 				context.beaconAnomalyNotify();
 				
 				networkChange = true;

--- a/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
+++ b/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
@@ -72,6 +72,8 @@ public class CABeaconHandler  {
 	{
 		this.context = context;
 		this.responseFrom = responseFrom;
+
+		context.getLogger().log(Level.WARNING, "CABeaconHandler for " + responseFrom + ": Speedup " + context.getBeaconSpeedup() + ", slowdown " + context.getBeaconSlowdown());
 	}
 	
 	/**
@@ -156,7 +158,7 @@ public class CABeaconHandler  {
 		else
 		{
 			// is this a server seen because of a restored network segment?
-			if (currentPeriod >= (averagePeriod * 1.5)) // TODO Slowdown factor
+			if (currentPeriod >= (averagePeriod * context.getBeaconSlowdown()))
 			{
 				if (currentPeriod >= (averagePeriod * 3.25))
 				{
@@ -181,7 +183,7 @@ public class CABeaconHandler  {
 			}
 			// is this a server seen because of reboot
 			// (beacons come at a higher rate just after the)
-			else if (periodStabilized  &&  currentPeriod <= (averagePeriod * 0.6)) // TODO Speedup factor
+			else if (periodStabilized  &&  currentPeriod <= (averagePeriod * context.getBeaconSpeedup()))
 			{
 				// server restarted...
 				context.getLogger().log(Level.WARNING, "Fast 'reboot' beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);

--- a/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
+++ b/src/core/com/cosylab/epics/caj/impl/CABeaconHandler.java
@@ -73,7 +73,7 @@ public class CABeaconHandler  {
 		this.context = context;
 		this.responseFrom = responseFrom;
 
-		context.getLogger().log(Level.FINE, "CABeaconHandler for " + responseFrom + ": Speedup " + context.getBeaconSpeedup() + ", slowdown " + context.getBeaconSlowdown());
+		context.getLogger().log(Level.FINE, () -> "CABeaconHandler for " + responseFrom + ": Speedup " + context.getBeaconSpeedup() + ", slowdown " + context.getBeaconSlowdown());
 	}
 	
 	/**
@@ -103,7 +103,7 @@ public class CABeaconHandler  {
 		if (lastBeaconTimeStamp == Long.MIN_VALUE)
 		{
 			// new server up...
-			context.getLogger().log(Level.INFO, "New server beacon " + responseFrom);
+			context.getLogger().log(Level.INFO, () -> "New server beacon " + responseFrom);
 			context.beaconAnomalyNotify();
 			
 			if (remoteTransportRevision >= 10)
@@ -162,7 +162,7 @@ public class CABeaconHandler  {
 			{
 				if (currentPeriod >= (averagePeriod * 3.25))
 				{
-					context.getLogger().log(Level.INFO, "Restored network segment beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
+					context.getLogger().log(Level.INFO, () -> "Restored network segment beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
 					context.beaconAnomalyNotify();
 
 					// trigger network change on any 3 contiguous missing beacons 
@@ -177,7 +177,7 @@ public class CABeaconHandler  {
 				else
 				{
 					// something might be wrong...
-					context.getLogger().log(Level.INFO, "Delayed beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
+					context.getLogger().log(Level.INFO, () -> "Delayed beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
 					context.beaconAnomalyNotify();
 				}
 			}
@@ -186,7 +186,7 @@ public class CABeaconHandler  {
 			else if (periodStabilized  &&  currentPeriod <= (averagePeriod * context.getBeaconSpeedup()))
 			{
 				// server restarted...
-				context.getLogger().log(Level.INFO, "Fast 'reboot' beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
+				context.getLogger().log(Level.INFO, () -> "Fast 'reboot' beacon " + responseFrom + ", period was " + averagePeriod + ", now " + currentPeriod);
 				context.beaconAnomalyNotify();
 				
 				networkChange = true;

--- a/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
+++ b/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
@@ -243,7 +243,7 @@ public class ChannelSearchManager {
 	 */
 	private synchronized boolean generateSearchRequestMessage(CAJChannel channel, boolean allowNewFrame)
 	{
-		context.getLogger().log(Level.INFO, "ChannelSearchManager searches " + channel.getName() + " via " + context.getBroadcastTransport());
+		context.getLogger().log(Level.INFO, () -> "ChannelSearchManager searches " + channel.getName() + " via " + context.getBroadcastTransport());
 		boolean success = channel.generateSearchRequestMessage(context.getBroadcastTransport(), sendBuffer);
 		// buffer full, flush
 		if (!success)
@@ -264,7 +264,7 @@ public class ChannelSearchManager {
 			// CAJTransport already coalesces with its sendBuffer
 			channel.generateSearchRequestMessage(trn, client.sendBuffer);
 			try {
-				context.getLogger().log(Level.INFO, "ChannelSearchManager searches " + channel.getName() + " via " + client);
+				context.getLogger().log(Level.INFO, () -> "ChannelSearchManager searches " + channel.getName() + " via " + client);
 				trn.submit(client);
 				trn.flush(); // TODO: delay w/ timer?
 			} catch (IOException e) {

--- a/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
+++ b/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 
 import com.cosylab.epics.caj.CAJChannel;
 import com.cosylab.epics.caj.CAJContext;
@@ -242,6 +243,7 @@ public class ChannelSearchManager {
 	 */
 	private synchronized boolean generateSearchRequestMessage(CAJChannel channel, boolean allowNewFrame)
 	{
+		context.getLogger().log(Level.WARNING, "ChannelSearchManager searches " + channel.getName() + " via " + context.getBroadcastTransport());
 		boolean success = channel.generateSearchRequestMessage(context.getBroadcastTransport(), sendBuffer);
 		// buffer full, flush
 		if (!success)
@@ -262,6 +264,7 @@ public class ChannelSearchManager {
 			// CAJTransport already coalesces with its sendBuffer
 			channel.generateSearchRequestMessage(trn, client.sendBuffer);
 			try {
+				context.getLogger().log(Level.WARNING, "ChannelSearchManager searches " + channel.getName() + " via " + client);
 				trn.submit(client);
 				trn.flush(); // TODO: delay w/ timer?
 			} catch (IOException e) {

--- a/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
+++ b/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
@@ -35,7 +35,6 @@ public class ChannelSearchManager {
 	 */
 	private final int intervalMultiplier;
 
-	private static final int MIN_SEND_INTERVAL_MS_DEFAULT = 100;
 	private static final int INTERVAL_MULTIPLIER_DEFAULT = 2;
 	
 	private static final int MESSAGE_COALESCENCE_TIME_MS = 3;
@@ -193,8 +192,8 @@ public class ChannelSearchManager {
 	{
 		this.context = context;
 
-		minSendInterval = MIN_SEND_INTERVAL_MS_DEFAULT;
 		// Convert from seconds to milliseconds.
+		minSendInterval = (long) (context.getMinSearchInterval() * 1000);
 		maxSendInterval = (long) (context.getMaxSearchInterval() * 1000);
 		intervalMultiplier = INTERVAL_MULTIPLIER_DEFAULT;
 

--- a/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
+++ b/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
@@ -243,7 +243,7 @@ public class ChannelSearchManager {
 	 */
 	private synchronized boolean generateSearchRequestMessage(CAJChannel channel, boolean allowNewFrame)
 	{
-		context.getLogger().log(Level.WARNING, "ChannelSearchManager searches " + channel.getName() + " via " + context.getBroadcastTransport());
+		context.getLogger().log(Level.INFO, "ChannelSearchManager searches " + channel.getName() + " via " + context.getBroadcastTransport());
 		boolean success = channel.generateSearchRequestMessage(context.getBroadcastTransport(), sendBuffer);
 		// buffer full, flush
 		if (!success)
@@ -264,7 +264,7 @@ public class ChannelSearchManager {
 			// CAJTransport already coalesces with its sendBuffer
 			channel.generateSearchRequestMessage(trn, client.sendBuffer);
 			try {
-				context.getLogger().log(Level.WARNING, "ChannelSearchManager searches " + channel.getName() + " via " + client);
+				context.getLogger().log(Level.INFO, "ChannelSearchManager searches " + channel.getName() + " via " + client);
 				trn.submit(client);
 				trn.flush(); // TODO: delay w/ timer?
 			} catch (IOException e) {

--- a/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
+++ b/src/core/com/cosylab/epics/caj/impl/ChannelSearchManager.java
@@ -243,7 +243,7 @@ public class ChannelSearchManager {
 	 */
 	private synchronized boolean generateSearchRequestMessage(CAJChannel channel, boolean allowNewFrame)
 	{
-		context.getLogger().log(Level.INFO, () -> "ChannelSearchManager searches " + channel.getName() + " via " + context.getBroadcastTransport());
+		context.getLogger().log(Level.FINE, () -> "ChannelSearchManager searches " + channel.getName() + " via " + context.getBroadcastTransport());
 		boolean success = channel.generateSearchRequestMessage(context.getBroadcastTransport(), sendBuffer);
 		// buffer full, flush
 		if (!success)
@@ -264,7 +264,7 @@ public class ChannelSearchManager {
 			// CAJTransport already coalesces with its sendBuffer
 			channel.generateSearchRequestMessage(trn, client.sendBuffer);
 			try {
-				context.getLogger().log(Level.INFO, () -> "ChannelSearchManager searches " + channel.getName() + " via " + client);
+				context.getLogger().log(Level.FINE, () -> "ChannelSearchManager searches " + channel.getName() + " via " + client);
 				trn.submit(client);
 				trn.flush(); // TODO: delay w/ timer?
 			} catch (IOException e) {


### PR DESCRIPTION
The default handling of CA beacons and the associated restart of name searches for disconnected channels is adequate for a properly operating network with default EPICS_CA_BEACON_PERIOD of 15 seconds.
But it can result in broadcast storms when the beacon period is shortened, presumably to get faster 'disconnect' detection. As soon as at least one IOCs fails to dependably send beacons at that faster period, clients will see a beacon anomaly and restart their name searches. This can also be verified by running `casw`, which will indicate the beacon anomalies.

This change doesn't change the default behavior of the CA client, but turns some constants into configurable parameters, to allow site-specific settings.

Newly recognized system properties:

`com.cosylab.epics.caj.CAJContext.min_search_interval`
When searching for a channel, the client will send a first search request.
If there is no response, another search request follows at this minimum search interval,
then twice the min, doubling the interval for each search request until reaching
the already configurable `max_search_interval`.
This allows adjusting the `min_search_interval` from its default of 0.1 seconds
to a larger number, for example 0.5 seconds, to reduce the number of name search packets
on the network.

`com.cosylab.epics.caj.CAJContext.beacon_speedup`
The client measures the average period between beacons received from each CA server.
A beacon received at a faster rate than the average is considered a 'fast' beacon,
suggesting a CA server reboot, restarting the name searches for missing channels.
The threshold for a 'fast' beacon is
```
most_recent_beacon_period < average_beacon_period * beacon_speedup
```
and the default `beacon_speedup` is 0.8.
By configuring it to say 0.6 the client will be more tolerant about erroneous fast beacons.


`com.cosylab.epics.caj.CAJContext.beacon_slowdown`
Similar to the beacon speedup, any beacon received at a period
```
most_recent_beacon_period > average_beacon_period * beacon_slowdown
```
is considered a 'slow' beacon, suggesting a restored network segment and
also restarting the name searches for missing channels.
The default `beacon_slowdown` is 1.25.
By configuring it to say 1.5 the client will be more tolerant about erroneous slow beacons.

This change also adds more log messages which when enabled allow tracing of received beacons and the name searches that they trigger.

While there might be an overall better way to handle beacons, details can be tricky, so this change only introduces configuration parameters which keep the original default values and thus result in the same behavior.
The only modification in the logic is this part:
```
if (beaconSeqAdvance > 1 && beaconSeqAdvance < 4)
{
    // Ignore this beacon, but measure period of next beacon from this one
   lastBeaconTimeStamp = timestamp;
  return false;
}
```
When the sequence number of received beacons indicates that the client missed some beacons, it ignores them to 'get back in sync'. In that case it will now update the 'lastBeaconTimeStamp' to the one of the last beacon. Even if we chose to ignore that beacon, its time stamp is valid, and we must remember it because otherwise we'll compute the wrong beacon period when handling the next beacon.