### PR TITLE
Send EventCancelRequest right away

### DIFF
--- a/src/core/com/cosylab/epics/caj/impl/requests/EventCancelRequest.java
+++ b/src/core/com/cosylab/epics/caj/impl/requests/EventCancelRequest.java
@@ -14,6 +14,7 @@
 
 package com.cosylab.epics.caj.impl.requests;
 
+import com.cosylab.epics.caj.impl.Request;
 import com.cosylab.epics.caj.impl.Transport;
 
 /**
@@ -36,6 +37,11 @@ public class EventCancelRequest extends AbstractCARequest {
 		requestMessage = insertCAHeader(transport, null,
 										(short)2, (short)0, (short)dataType, (short)dataCount,
 										sid, subsid);
+	}
+
+	@Override
+	public byte getPriority() {
+		return Request.SEND_IMMEDIATELY_PRIORITY;
 	}
 
 }


### PR DESCRIPTION
The transport is closed after the request is created so it needs to be sent immediately. Fixes issue ControlSystemStudio/phoebus#1599