### PR TITLE
handle UTF-strings as pvnames - fixed UDP-datagram buffer sizes

### DIFF
--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -1004,9 +1004,9 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 		throws CAException, IllegalStateException {
 		checkState();
 		
-		if (name == null || name.length() == 0)
+		if (name == null || name.getBytes().length == 0)
 			throw new IllegalArgumentException("null or empty channel name");
-		else if (name.length() > Math.min(CAConstants.MAX_UDP_SEND - CAConstants.CA_MESSAGE_HEADER_SIZE, 0xFFFF))
+		else if (name.getBytes().length > Math.min(CAConstants.MAX_UDP_SEND - CAConstants.CA_MESSAGE_HEADER_SIZE, 0xFFFF))
 			throw new CAException("name too long");
 		
 		if (priority < Channel.PRIORITY_MIN || priority > Channel.PRIORITY_MAX)

--- a/src/core/com/cosylab/epics/caj/cas/handlers/CreateChannelResponse.java
+++ b/src/core/com/cosylab/epics/caj/cas/handlers/CreateChannelResponse.java
@@ -89,7 +89,7 @@ public class CreateChannelResponse extends AbstractCASResponseHandler {
 		String channelName = extractString(response[1], 0, payloadSize, false);
 
 		// check channel name lenght
-		if (channelName.length() > CAConstants.UNREASONABLE_CHANNEL_NAME_LENGTH)
+		if (channelName.getBytes().length > CAConstants.UNREASONABLE_CHANNEL_NAME_LENGTH)
 		{
 			context.getLogger().warning("Unreasonable channel name length, disconnecting client: " + transport.getRemoteAddress());
 			disconnect(transport);

--- a/src/core/com/cosylab/epics/caj/impl/requests/CreateChannelRequest.java
+++ b/src/core/com/cosylab/epics/caj/impl/requests/CreateChannelRequest.java
@@ -51,7 +51,7 @@ public class CreateChannelRequest extends AbstractCARequest {
 		 
 		int binaryNameLength = 0;
 		if (channelName != null)
-			binaryNameLength = channelName.length() + 1;
+			binaryNameLength = channelName.getBytes().length + 1;
 		 
 		int alignedMessageSize = calculateAlignedSize(8, CAConstants.CA_MESSAGE_HEADER_SIZE + binaryNameLength);
 		requestMessage = ByteBuffer.allocate(alignedMessageSize);

--- a/src/core/com/cosylab/epics/caj/impl/requests/SearchRequest.java
+++ b/src/core/com/cosylab/epics/caj/impl/requests/SearchRequest.java
@@ -45,10 +45,10 @@ public class SearchRequest extends AbstractCARequest {
 	public static final ByteBuffer generateSearchRequestMessage(Transport transport, ByteBuffer requestMessage,
 			String name, int cid)
 	{
-		if (name.length() > Math.min(CAConstants.MAX_UDP_SEND - CAConstants.CA_MESSAGE_HEADER_SIZE, 0xFFFF))
+            if (name.getBytes().length > Math.min(CAConstants.MAX_UDP_SEND - CAConstants.CA_MESSAGE_HEADER_SIZE, 0xFFFF))
 			throw new IllegalArgumentException("name too long");
 
-		int alignedMessageSize = calculateAlignedSize(8, CAConstants.CA_MESSAGE_HEADER_SIZE + name.length() + 1);
+            int alignedMessageSize = calculateAlignedSize(8, CAConstants.CA_MESSAGE_HEADER_SIZE + name.getBytes().length + 1);
 		if (requestMessage == null)
 			requestMessage = ByteBuffer.allocate(alignedMessageSize);
 		else if (requestMessage.remaining() < alignedMessageSize)

--- a/src/core/gov/aps/jca/cas/ProcessVariable.java
+++ b/src/core/gov/aps/jca/cas/ProcessVariable.java
@@ -70,7 +70,7 @@ public abstract class ProcessVariable {
 	 */
 	public ProcessVariable(String name, ProcessVariableEventCallback eventCallback)
 	{
-		if (name == null || name.length() == 0)
+                if (name == null || name.getBytes().length == 0)
 			throw new IllegalArgumentException("non empty name expected.");
 
 		/*


### PR DESCRIPTION
This fixes a bug in handling UTF-8/16 PVnames.

Querying for a PV with german umlauts (due to a typo), all IOCs issued error-messages like 

> unterminated PV name in UDP search request?

and older ca-gateways even hung consuming 100%CPU and stop doing any I/O.

Test with pv-name  "Führungsgröße":

- name.length() says 13, but
- name.getBytes().length gives 16

13 bytes would have fit in the default UDP-datagram buffer for name-resolution requests (size  = 16 bytes), but the 16 real bytes left no space for the terminating NULL-byte, which caused all kinds of errors.

With the proposed fix, JCA neither crashes any gateways nor produces any error messages on IOCs/Gateways. 
An existing PV named "Führungsgröße" now connects properly and returns values.