### PR TITLE
Separate TCP and UDP server port variable in CAJServerContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ nbactions.xml
 *.log
 /.settings
 .project
+/.idea/
+/jca.iml

--- a/src/core/com/cosylab/epics/caj/cas/CASAcceptor.java
+++ b/src/core/com/cosylab/epics/caj/cas/CASAcceptor.java
@@ -65,7 +65,7 @@ public class CASAcceptor implements ReactorHandler {
 		
 		// update port, if dynamically assigned port is used
 		if (assignedPort != port)
-			((CAJServerContext)context).setServerPort(assignedPort);
+			((CAJServerContext)context).setTcpServerPort(assignedPort);
 	}
 
 	/**

--- a/src/core/com/cosylab/epics/caj/impl/BroadcastTransport.java
+++ b/src/core/com/cosylab/epics/caj/impl/BroadcastTransport.java
@@ -16,6 +16,7 @@ package com.cosylab.epics.caj.impl;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
@@ -26,6 +27,7 @@ import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.cosylab.epics.caj.cas.CAJServerContext;
 import com.cosylab.epics.caj.impl.reactor.ReactorHandler;
 
 /**
@@ -133,8 +135,16 @@ public class BroadcastTransport implements Transport, ReactorHandler {
 	 */
 	public void bind(boolean reuseAddress) throws SocketException
 	{
-		channel.socket().setReuseAddress(reuseAddress);
-		channel.socket().bind(connectAddress);
+		DatagramSocket socket = channel.socket();
+
+		socket.setReuseAddress(reuseAddress);
+		socket.bind(connectAddress);
+
+		int assignedPort = socket.getLocalPort();
+
+		// Only necessary if connectAddress contains port = 0, but harmless either way
+		((CAJServerContext)context).setUdpServerPort(assignedPort);
+		context.getLogger().info("Server listening for pv name search on UDP port: " + assignedPort);
 	}
 	
 	/**

--- a/test/org/epics/jca/DynamicPortTest.java
+++ b/test/org/epics/jca/DynamicPortTest.java
@@ -1,0 +1,73 @@
+package org.epics.jca;
+
+import com.cosylab.epics.caj.CAJChannel;
+import com.cosylab.epics.caj.cas.util.MemoryProcessVariable;
+import gov.aps.jca.CAException;
+import gov.aps.jca.JCALibrary;
+import gov.aps.jca.TimeoutException;
+import gov.aps.jca.configuration.DefaultConfiguration;
+import gov.aps.jca.dbr.DBRType;
+import gov.aps.jca.dbr.DBR_String;
+import gov.aps.jca.event.MonitorEvent;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class DynamicPortTest {
+    private EmbeddedIoc ioc;
+    private MonitorClient client;
+    private String[] pvs;
+
+    @Before
+    public void setup() throws CAException {
+        ioc = new EmbeddedIoc();
+        client = new MonitorClient();
+
+        pvs = new String[]{"channel1", "channel2"};
+
+        for(String pv: pvs) {
+            ioc.registerPv(new MemoryProcessVariable(pv, null, DBRType.STRING, new String[]{"Hello from " + pv + "!"}));
+        }
+
+        DefaultConfiguration config = new DefaultConfiguration("config");
+        config.setAttribute("class", JCALibrary.CHANNEL_ACCESS_JAVA);
+        config.setAttribute("auto_addr_list", "NO");
+        config.setAttribute("addr_list", ioc.getAddress());
+
+        long pollWaitMillis = 1000;
+        long pendIOTimeoutMillis = 2000;
+
+        ioc.start();
+        client.start(config, pvs, pollWaitMillis, pendIOTimeoutMillis);
+    }
+
+    @After
+    public void tearDown() throws CAException {
+        client.stop();
+        ioc.stop();
+    }
+
+    @Test
+    public void basicTest() throws InterruptedException, CAException, TimeoutException {
+        List<MonitorEvent> events = client.poll(); // Grabs most recent update, if any
+
+        int actualCount = events.size();
+        String actualC2Value = null;
+
+        for(MonitorEvent event: events) {
+            CAJChannel channel = (CAJChannel)event.getSource();
+
+            if("channel2".equals(channel.getName())) {
+                DBR_String dbr = (DBR_String)event.getDBR();
+                String[] strArray = ((gov.aps.jca.dbr.STRING) dbr).getStringValue();
+                actualC2Value = strArray[0];
+            }
+        }
+
+        Assert.assertEquals(2, actualCount);
+        Assert.assertEquals("Hello from channel2!", actualC2Value);
+    }
+}

--- a/test/org/epics/jca/EmbeddedIoc.java
+++ b/test/org/epics/jca/EmbeddedIoc.java
@@ -1,0 +1,57 @@
+package org.epics.jca;
+
+import com.cosylab.epics.caj.cas.CAJServerContext;
+import com.cosylab.epics.caj.cas.util.DefaultServerImpl;
+import gov.aps.jca.CAException;
+import gov.aps.jca.JCALibrary;
+import gov.aps.jca.cas.ProcessVariable;
+
+public class EmbeddedIoc {
+    private JCALibrary jca;
+    private DefaultServerImpl server;
+    private CAJServerContext context;
+
+    public EmbeddedIoc() throws CAException {
+        this(0); // 0 means dynamically assign
+    }
+
+    public EmbeddedIoc(int udpPort) throws CAException {
+        jca = JCALibrary.getInstance();
+
+        server = new DefaultServerImpl();
+        context = new CAJServerContext();
+        context.setUdpServerPort(udpPort);
+        context.initialize(server);
+    }
+
+    /**
+     * The address to the server's UDP pv name search socket as one would use in a client addr_list.
+     *
+     * @return The server's pv name search UDP socket address
+     */
+    public String getAddress() {
+        return "localhost:" + context.getUdpServerPort();
+    }
+
+    public void registerPv(ProcessVariable pv) {
+        server.registerProcessVariable(pv);
+    }
+
+    public ProcessVariable unregisterPv(String name) {
+        return server.unregisterProcessVariable(name);
+    }
+
+    public void start() {
+        new Thread(() -> {
+            try {
+                context.run(0);
+            } catch (CAException e) {
+                e.printStackTrace();
+            }
+        }).start();
+    }
+
+    public void stop() throws CAException {
+        context.destroy();
+    }
+}

--- a/test/org/epics/jca/MonitorClient.java
+++ b/test/org/epics/jca/MonitorClient.java
@@ -1,0 +1,73 @@
+package org.epics.jca;
+
+import com.cosylab.epics.caj.CAJChannel;
+import com.cosylab.epics.caj.CAJContext;
+import gov.aps.jca.CAException;
+import gov.aps.jca.JCALibrary;
+import gov.aps.jca.Monitor;
+import gov.aps.jca.TimeoutException;
+import gov.aps.jca.configuration.Configuration;
+import gov.aps.jca.event.MonitorEvent;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MonitorClient {
+    private Map<String, MonitorEvent> latest = new ConcurrentHashMap<>();
+
+    private static final JCALibrary JCA_LIBRARY = JCALibrary.getInstance();
+    private Configuration config = null;
+    private CAJContext context;
+    private String[] pvs;
+    private long pollWaitMillis;
+    private float pendIOTimeoutSeconds;
+
+    public void start(Configuration config, String[] pvs, long pollWaitMillis, long pendIOTimeoutMillis) {
+        this.config = config;
+        this.pvs = pvs;
+        this.pollWaitMillis = pollWaitMillis;
+        this.pendIOTimeoutSeconds = pendIOTimeoutMillis / 1000.0f;
+    }
+
+    public List<MonitorEvent> poll() throws CAException, TimeoutException, InterruptedException {
+        if(context == null) {
+            createContext();
+        }
+
+        synchronized (this) {
+            wait(pollWaitMillis); // Max update frequency; too fast is taxing and unnecessary work; too slow means delayed monitor updates
+        }
+
+        List<MonitorEvent> events = null; // Return null if no updates
+
+        if(!latest.isEmpty()) {
+            events = new ArrayList<>(latest.values());
+            latest.clear();
+        }
+
+        return events;
+    }
+
+    private void createContext() throws CAException, TimeoutException {
+        context = (CAJContext) JCA_LIBRARY.createContext(config);
+
+        List<CAJChannel> channels = new ArrayList<>();
+
+        for(String pv: pvs) {
+            CAJChannel channel = (CAJChannel) context.createChannel(pv);
+            channels.add(channel);
+        }
+
+        context.pendIO(pendIOTimeoutSeconds);
+
+        for(CAJChannel channel: channels) {
+            channel.addMonitor(Monitor.VALUE, ev -> latest.put(channel.getName(), ev));
+        }
+
+        context.pendIO(pendIOTimeoutSeconds);
+    }
+
+    public void stop() throws CAException {
+        context.destroy();
+    }
+}

--- a/test/org/epics/jca/MultiServerTest.java
+++ b/test/org/epics/jca/MultiServerTest.java
@@ -1,0 +1,76 @@
+package org.epics.jca;
+
+import com.cosylab.epics.caj.CAJChannel;
+import com.cosylab.epics.caj.cas.util.MemoryProcessVariable;
+import gov.aps.jca.CAException;
+import gov.aps.jca.JCALibrary;
+import gov.aps.jca.TimeoutException;
+import gov.aps.jca.configuration.DefaultConfiguration;
+import gov.aps.jca.dbr.DBRType;
+import gov.aps.jca.dbr.DBR_String;
+import gov.aps.jca.event.MonitorEvent;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class MultiServerTest {
+    private EmbeddedIoc ioc1;
+    private EmbeddedIoc ioc2;
+    private MonitorClient client;
+    private String[] pvs;
+
+    @Before
+    public void setup() throws CAException {
+        ioc1 = new EmbeddedIoc();
+        ioc2 = new EmbeddedIoc();
+        client = new MonitorClient();
+
+        pvs = new String[]{"channel1", "channel2"};
+
+        ioc1.registerPv(new MemoryProcessVariable("channel1", null, DBRType.STRING, new String[]{"Hello from channel1!"}));
+        ioc2.registerPv(new MemoryProcessVariable("channel2", null, DBRType.STRING, new String[]{"Hello from channel2!"}));
+
+        DefaultConfiguration config = new DefaultConfiguration("config");
+        config.setAttribute("class", JCALibrary.CHANNEL_ACCESS_JAVA);
+        config.setAttribute("auto_addr_list", "NO");
+        config.setAttribute("addr_list", ioc1.getAddress() + " " + ioc2.getAddress());
+
+        long pollWaitMillis = 1000;
+        long pendIOTimeoutMillis = 2000;
+
+        ioc1.start();
+        ioc2.start();
+        client.start(config, pvs, pollWaitMillis, pendIOTimeoutMillis);
+    }
+
+    @After
+    public void tearDown() throws CAException {
+        client.stop();
+        ioc1.stop();
+        ioc2.stop();
+    }
+
+    @Test
+    public void basicTest() throws InterruptedException, CAException, TimeoutException {
+        List<MonitorEvent> events = client.poll(); // Grabs most recent update, if any
+
+        int actualCount = events.size();
+        String actualC2Value = null;
+
+        for(MonitorEvent event: events) {
+            CAJChannel channel = (CAJChannel)event.getSource();
+
+            if("channel2".equals(channel.getName())) {
+                DBR_String dbr = (DBR_String)event.getDBR();
+                String[] strArray = ((gov.aps.jca.dbr.STRING) dbr).getStringValue();
+                actualC2Value = strArray[0];
+            }
+        }
+
+        Assert.assertEquals(2, actualCount);
+        Assert.assertEquals("Hello from channel2!", actualC2Value);
+    }
+}


### PR DESCRIPTION
This change does NOT modify the configuration options users have nor does it change the behavior of existing methods.   It does add new get/set methods for TCP Server Port and UDP Server port.  The existing get/set Server Port method has the deprecated annotation added, but it does the same as it always has done - return the TCP port, which is most of the time also the UDP port.

The biggest change is now when users use serverPort = 0 the dynamically assigned UDP port is now accessible (before there was no way to determine what it was as getServerPort returned the dynamically assigned TCP port, which was dynamically assigned after the UDP port had already been dynamically assigned itself)

JUnit tests are included to show that you can now have multiple embedded IOCs (CAJ Servers)  running or otherwise request a CAJ Server with dynamically assigned ports to avoid conflicts with localhost.