### PR TITLE
Wrap EPICS_CA.. format errors into more helpful exceptions

### DIFF
--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -446,22 +446,41 @@ public class CAJContext extends Context implements CAContext, CAJConstants, Conf
 			if (tmp != null) nameServersList = tmp;
 
 			tmp = System.getenv("EPICS_CA_CONN_TMO");
-			if (tmp != null) connectionTimeout = Float.parseFloat(tmp);
+			if (tmp != null)
+				try { connectionTimeout = Float.parseFloat(tmp); }
+				catch (Exception ex)
+				{   logger.log(Level.WARNING, "Cannot parse EPICS_CA_CONN_TMO='" + tmp + "'", ex); }
 
 			tmp = System.getenv("EPICS_CA_BEACON_PERIOD");
-			if (tmp != null) beaconPeriod = Float.parseFloat(tmp);
+			if (tmp != null)
+				try { beaconPeriod = Float.parseFloat(tmp); }
+				catch (Exception ex)
+				{   logger.log(Level.WARNING, "Cannot parse EPICS_CA_BEACON_PERIOD='" + tmp + "'", ex); }
 
 			tmp = System.getenv("EPICS_CA_REPEATER_PORT");
-			if (tmp != null) repeaterPort = Integer.parseInt(tmp);
+			if (tmp != null)
+				try { repeaterPort = Integer.parseInt(tmp); }
+				catch (Exception ex)
+				{   logger.log(Level.WARNING, "Cannot parse EPICS_CA_REPEATER_PORT='" + tmp + "'", ex); }
 
 			tmp = System.getenv("EPICS_CA_SERVER_PORT");
-			if (tmp != null) serverPort = Integer.parseInt(tmp);
+			if (tmp != null)
+				try { serverPort = Integer.parseInt(tmp); }
+				catch (Exception ex)
+				{   logger.log(Level.WARNING, "Cannot parse EPICS_CA_SERVER_PORT='" + tmp + "'", ex); }
 
 			tmp = System.getenv("EPICS_CA_MAX_ARRAY_BYTES");
-			if (tmp != null) maxArrayBytes = Integer.parseInt(tmp);
+			if (tmp != null)
+				try { maxArrayBytes = Integer.parseInt(tmp); }
+				catch (Exception ex)
+				{   logger.log(Level.WARNING, "Cannot parse EPICS_CA_MAX_ARRAY_BYTES='" + tmp + "'", ex); }
+
 
 			tmp = System.getenv("EPICS_CA_MAX_SEARCH_PERIOD");
-			if (tmp != null) maxSearchInterval = Float.parseFloat(tmp);
+			if (tmp != null)
+				try { maxSearchInterval = Float.parseFloat(tmp); }
+				catch (Exception ex)
+				{   logger.log(Level.WARNING, "Cannot parse EPICS_CA_MAX_SEARCH_PERIOD='" + tmp + "'", ex); }
 		}
 		else
 		{


### PR DESCRIPTION
.. so end user can tell which EPICS_CA_.. setting caused the problem
without having to check the source code.

This is to alleviate issues like https://github.com/ornl-epics/pvws/issues/9 where
```
# Set to empty
export EPICS_CA_MAX_ARRAY_BYTES=
```
instead of
```
# either undefine it
unset EPICS_CA_MAX_ARRAY_BYTES
# or set valid number
EPICS_CA_MAX_ARRAY_BYTES=1000000
```
results in JCA initialization error that's hard to decipher without looking at the source code.

@shroffk @tynanford This compiled and passes unit tests (`mvn clean install`), but I have no idea how to test it, because that seems to require
1) Increment version of jca and release
2) Increment its version in core-epics, then update that and release
3) Increment core-epics version in phoebus' core-pv, then update that version and release
4) Increment core-pv's version in pvws, then build that and test