### PR TITLE
Fix for blocking failed tcp connections

### DIFF
--- a/src/core/com/cosylab/epics/caj/impl/CAConnector.java
+++ b/src/core/com/cosylab/epics/caj/impl/CAConnector.java
@@ -226,12 +226,12 @@ public class CAConnector implements Connector {
 		
 		public RetryFailedConnection()
 		{
-			this.retryTime = System.currentTimeMillis() + delay;
+			increaseRetryTime();
 		}
 		
 		public void increaseRetryTime()
 		{
-			this.retryTime = System.currentTimeMillis() + delay;
+			retryTime = System.currentTimeMillis() + delay;
 			delay = delay * 2;
 			if (delay > MAX_DELAY_TIME)
 			{

--- a/src/core/com/cosylab/epics/caj/impl/CAConnector.java
+++ b/src/core/com/cosylab/epics/caj/impl/CAConnector.java
@@ -207,7 +207,7 @@ public class CAConnector implements Connector {
 			}
 
 			context.getLogger().finest("Openning socket to CA server " + address + ", attempt " + (tryCount+1) + ".");
-			
+
 			try
 			{
 				return SocketChannel.open(address);

--- a/src/core/com/cosylab/epics/caj/impl/CAConnector.java
+++ b/src/core/com/cosylab/epics/caj/impl/CAConnector.java
@@ -54,7 +54,7 @@ public class CAConnector implements Connector {
 	/**
 	 * Map tracking failed TCP connections
 	 */
-	private final Map<InetSocketAddress, FailedConnection> failedToConnect = new HashMap<InetSocketAddress, FailedConnection>();
+	private final Map<InetSocketAddress, RetryFailedConnection> failedToConnect = new HashMap<InetSocketAddress, RetryFailedConnection>();
 
 	/**
 	 * @param context
@@ -166,7 +166,7 @@ public class CAConnector implements Connector {
 					failedToConnect.get(address).increaseRetryTime();
 				} else // Otherwise add to failed connections map
 				{
-					failedToConnect.put(address, new FailedConnection(address));
+					failedToConnect.put(address, new RetryFailedConnection());
 				}
 				
 				throw new ConnectionException("Failed to connect to '" + address + "'.", address, th);
@@ -207,6 +207,7 @@ public class CAConnector implements Connector {
 			}
 
 			context.getLogger().finest("Openning socket to CA server " + address + ", attempt " + (tryCount+1) + ".");
+			
 			try
 			{
 				return SocketChannel.open(address);
@@ -226,15 +227,13 @@ public class CAConnector implements Connector {
 	 * Class defining the next time to retry the connection for
 	 * a given socket address.
 	 */
-	private class FailedConnection {
-		private InetSocketAddress address;
+	private class RetryFailedConnection {
 		private long delay = 1000;
 		private long retryTime;
 		private static final long MAX_DELAY_TIME = 120000;
 		
-		public FailedConnection(InetSocketAddress address)
+		public RetryFailedConnection()
 		{
-			this.address = address;
 			this.retryTime = System.currentTimeMillis() + delay;
 		}
 		


### PR DESCRIPTION
This PR is a proposed fix for the issue described in #36 .

Summary of the issue: If an IOC is in an environment where it can respond to UDP broadcasts but not to TCP requests, then any subsequent TCP connection to a healthy IOC is blocked. In our use-case we found that CS-Studio (which uses the JCA library) would take a long time to display values of PVs from a healthy IOC if the screen also contained PVs from an ill IOC. 

Issue: each time the ill IOC responds to the UDP broadcast, the JCA library spends time (~3 secs) trying to establish a TCP connection. This fails and so the UDP broadcast is sent out again, which gets a response and again it tries to make the TCP connection. This essentially ends up blocking any other TCP connections to healthy IOCs.

Solution: in the linked issue above we have discussed that if the TCP connection fails we can't similar stop any future connection attempts as then the client will not connect when the ill IOC is fixed. Instead I have tested adding an increasing delay between each successive TCP connection attempt to an IP address if it should fail. The assumption here is that the underlying reason that an 'ill' IOC cannot respond to the TCP request is due to a networking problem on the host server and so we can based the fix on the specific IP address. The increasing delay means that we do not tie up the TCP connection code with the unsuccessful attempts and it allows other connections to healthy IOCS to be made.

This is a relatively 'simple' fix with minimal changes and does not require a larger re-work of the connection process. Any thoughts/comments/feedback would be appreciated as to whether this is a suitable/beneficial fix.