### PR TITLE
Fix failing CI test on Java 16 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,11 @@
                     </systemProperties>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+            </plugin>
             <!-- Required add sources to deployment -->
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
+                <version>0.8.7</version>
             </plugin>
             <!-- Required add sources to deployment -->
             <plugin>


### PR DESCRIPTION
I noticed that one of the tests is failing under the Java 16 build with the error:
```
Running com.cosylab.epics.caj.cas.test.GetAndPutTest
java.lang.instrument.IllegalClassFormatException: Error while instrumenting sun/util/resources/cldr/provider/CLDRLocaleDataMetaInfo.
	at org.jacoco.agent.rt.internal_43f5073.CoverageTransformer.transform(CoverageTransformer.java:94)
```
This is due to an outdated version of the jacoco plugin. This error can be fixed by including the jacoco-maven-plugin in the pom.xml and specifying the required version, which looks to be 0.8.7 as this officially support Java 16 (see https://www.jacoco.org/jacoco/trunk/doc/changes.html).  