### PR TITLE
#72 simplify the jca versioning support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,25 @@
                 <directory>src/core/gov/aps/jca</directory>
                 <includes>
                     <include>JCALibrary.properties</include>
+                    <include>version.properties</include>
                 </includes>
             </resource>
+            <resource>
+                <targetPath>gov/aps/jca</targetPath>
+				<directory>src/core/gov/aps/jca</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>version.properties</include>
+				</includes>
+			</resource>
+			<resource>
+                <targetPath>gov/aps/jca</targetPath>
+				<directory>src/core/gov/aps/jca</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>version.properties</exclude>
+				</excludes>
+			</resource>
         </resources>
         <plugins>
             <!-- Includes the OSGi manifest -->

--- a/src/core/com/cosylab/epics/caj/CAJContext.java
+++ b/src/core/com/cosylab/epics/caj/CAJContext.java
@@ -80,32 +80,11 @@ import com.cosylab.epics.caj.util.logging.ConsoleLogHandler;
 public class CAJContext extends Context implements CAContext, CAJConstants, Configurable {
 
     /**
-     * Major version.
-     */
-    private static final int CAJ_VERSION_MAJOR = 1;
-    
-    /**
-     * Minor version.
-     */
-    private static final int CAJ_VERSION_MINOR = 1;
-
-    /**
-     * Maintenance version.
-     */
-    private static final int CAJ_VERSION_MAINTENANCE = 16;
-
-    /**
-     * Development version.
-     */
-    private static final int CAJ_VERSION_DEVELOPMENT = 1;
-
-    /**
      * Version.
      */
     public static final Version VERSION = new Version(
             "Channel Access in Java", "Java",
-            CAJ_VERSION_MAJOR, CAJ_VERSION_MINOR,
-            CAJ_VERSION_MAINTENANCE, CAJ_VERSION_DEVELOPMENT);
+            JCALibrary.getInstance().getVersion());
 	  
     /**
      * String value of the JVM property key to turn on single threaded model. 

--- a/src/core/com/cosylab/epics/caj/cas/CAJServerContext.java
+++ b/src/core/com/cosylab/epics/caj/cas/CAJServerContext.java
@@ -69,33 +69,13 @@ public class CAJServerContext extends ServerContext implements CAContext, Config
 		System.setProperty("java.net.preferIPv4Stack", "true");
 	}
 
-    /**
-     * Major version.
-     */
-    private static final int CAS_VERSION_MAJOR = 1;
-    
-    /**
-     * Minor version.
-     */
-    private static final int CAS_VERSION_MINOR = 1;
-
-    /**
-     * Maintenance version.
-     */
-    private static final int CAS_VERSION_MAINTENANCE = 16;
-
-    /**
-     * Development version.
-     */
-    private static final int CAS_VERSION_DEVELOPMENT = 1;
 
     /**
      * Version.
      */
     public static final Version VERSION = new Version(
             "Channel Access Server in Java", "Java",
-            CAS_VERSION_MAJOR, CAS_VERSION_MINOR,
-            CAS_VERSION_MAINTENANCE, CAS_VERSION_DEVELOPMENT);
+            JCALibrary.getInstance().getVersion());
 	  
    
     /**

--- a/src/core/gov/aps/jca/JCALibrary.java
+++ b/src/core/gov/aps/jca/JCALibrary.java
@@ -66,10 +66,14 @@ import java.util.*;
  */
 public final class JCALibrary {
   
+  @Deprecated	
   static private final int VERSION=2;
+  @Deprecated	
   static private final int REVISION=4;
   // TODO version to be incremented - do not forget
+  @Deprecated	
   static private final int MODIFICATION=6;
+  @Deprecated	
   static private final String VERSION_STRING=""+VERSION+"."+REVISION+"."+MODIFICATION;
   
   static private JCALibrary _instance=null;
@@ -94,9 +98,18 @@ public final class JCALibrary {
     String fileSep=System.getProperty( "file.separator" );
     String path=null;
     
+    // Read the version
+    try (InputStream input = JCALibrary.class.getResourceAsStream("version.properties")) {
+        // load a properties file
+        if (input == null)
+            throw new RuntimeException("resource not found.");
+        versionProperties.load(input);
+    } catch (IOException ex) {
+        System.out.println( "Unable to load default configuration located in 'version.properties' resource: " + ex.getMessage() );
+    }
+    
     // Read Configuration
-    try {
-        InputStream is = JCALibrary.class.getResourceAsStream( "JCALibrary.properties" );
+    try (InputStream is = JCALibrary.class.getResourceAsStream( "JCALibrary.properties" );) {        
         if (is == null)
             throw new RuntimeException("resource not found.");
         _builtinProperties.load( is );
@@ -125,12 +138,16 @@ public final class JCALibrary {
     
   }
   
+  public String getVersion() {
+		return versionProperties.getProperty("jca.version");
+  }
+
   /**Getter method for the version number.
    * @return the JCALibrary version number.
    */
-  public int getVersion() {
-    return VERSION;
-  }
+//  public int getVersion() {
+//    return VERSION;
+//  }
   
   /**Getter method for the revision number.
    * @return the JCALibrary revision number.
@@ -150,7 +167,7 @@ public final class JCALibrary {
    * @return the JCALibrary version string.
    */
   public String getVersionString() {
-    return VERSION_STRING;
+    return getVersion();
   }
   
   /** Print some basic info about the JCALibrary to the standard output stream.
@@ -167,10 +184,11 @@ public final class JCALibrary {
   }
   
   public String toString() {
-    return JCALibrary.class.getName()+"["+getVersionString()+"]";
+    return JCALibrary.class.getName()+"["+getVersion()+"]";
   }
   
   // PROPERTIES
+  Properties versionProperties=new Properties();
   Properties _builtinProperties=new Properties();
   Properties _defaultProperties=new Properties( _builtinProperties );
   Properties _properties=new Properties( _defaultProperties );

--- a/src/core/gov/aps/jca/JCALibrary.java
+++ b/src/core/gov/aps/jca/JCALibrary.java
@@ -139,7 +139,7 @@ public final class JCALibrary {
   }
   
   public String getVersion() {
-		return versionProperties.getProperty("jca.version");
+      return versionProperties.getProperty("jca.version");
   }
 
   /**Getter method for the version number.

--- a/src/core/gov/aps/jca/Version.java
+++ b/src/core/gov/aps/jca/Version.java
@@ -38,23 +38,32 @@ public class Version {
     private String implementationLanguage;
     
     /**
+     * 
+     */
+    private String version;
+    
+    /**
      * @see Version#getMajorVersion()
      */
+    @Deprecated
     private int majorVersion;
     
     /**
      * @see Version#getMinorVersion()
      */
+    @Deprecated
     private int minorVersion;
     
     /**
      * @see Version#getMaintenanceVersion()
      */
+    @Deprecated
     private int maintenanceVersion;
     
     /**
      * @see Version#getDevelopmentVersion()
      */
+    @Deprecated
     private int developmentVersion;
     
     /**
@@ -66,6 +75,7 @@ public class Version {
      * @param maintenanceVersion	maintenance version.
      * @param developmentVersion	development version.
      */
+    @Deprecated
     public Version(String productName, String implementationLangugage,
             	   int majorVersion, int minorVersion, int maintenanceVersion,
             	   int developmentVersion)
@@ -82,6 +92,21 @@ public class Version {
     }
     
     /**
+     * Version consturctor.
+     * @param productName	product name.
+     * @param implementationLangugage	impementation language.
+     * @param version	a string representing the version number.
+     */
+    public Version(String productName, String implementationLangugage, String version)
+    {
+
+        this.productName = productName;
+        this.implementationLanguage = implementationLangugage;
+        this.version = version;
+    }
+    
+    
+    /**
      * Get the long version string. Version String formatted like <BR><CODE>
      * "<B>ProductName </B> \[<B>ImplementationLanguage</B>\] 'v'v.r[.dd|<B>D</B>nn]"
      * </CODE> <BR>e.g. <BR><CODE>"<B>CAJ </B> [<B>Java</B>] v1.0.1"</CODE>
@@ -95,16 +120,12 @@ public class Version {
                 + " ["
                 + getImplementationLanguage()
                 + "] v"
-                + getMajorVersion()
-                + "."
-                + getMinorVersion()
-                + "."
-                + ((getDevelopmentVersion() > 0) ? ("D" + getDevelopmentVersion())
-                        : ("" + getMaintenanceVersion()));
+                + getVersion();
     }
 
-    /**
-     * Get the basic version string. Version String formatted like <BR><CODE>
+
+	/**
+     * Get the basic version string. Vesion String formatted like <BR><CODE>
      * "<B>ProductName </B> 'v'v.r[.dd|<B>D</B>nn]"
      * </CODE> <BR>e.g. <BR><CODE>"<B>CAJ </B> v1.0.1"</CODE>
      * <BR>
@@ -115,12 +136,7 @@ public class Version {
     {
         return getProductName()
                 + " v"
-                + getMajorVersion()
-                + "."
-                + getMinorVersion()
-                + "."
-                + ((getDevelopmentVersion() > 0) ? ("D" + getDevelopmentVersion())
-                        : ("" + getMaintenanceVersion()));
+                + getVersion();
     }
     
     /**
@@ -139,6 +155,14 @@ public class Version {
         return implementationLanguage;
     }
 
+
+    /**
+     * 
+     * @return version number
+     */
+    private String getVersion() {
+		return version;
+	}
     /**
      * Major version number. This changes only when there is a
      * significant, externally apparent enhancement from the previous release.
@@ -147,6 +171,7 @@ public class Version {
      * Clients should carefully consider the implications of new versions as
      * external interfaces and behaviour may have changed.
      */
+    @Deprecated
     public int getMajorVersion()
     {
         return majorVersion;
@@ -161,6 +186,7 @@ public class Version {
      * <li>its designated as a reference release</li>
      * </ul>
      */
+    @Deprecated
     public int getMinorVersion()
     {
         return minorVersion;
@@ -173,6 +199,7 @@ public class Version {
      * contains no API changes. When missing, it designates the final and
      * complete development drop for a release.
      */
+    @Deprecated
     public int getMaintenanceVersion()
     {
         return maintenanceVersion;
@@ -192,6 +219,7 @@ public class Version {
      * Each 'D' drops can contain functional enhancements as well as defect
      * fixes. 'D' drops may not be as stable as the final releases.
      */
+    @Deprecated
     public int getDevelopmentVersion()
     {
         return developmentVersion;

--- a/src/core/gov/aps/jca/Version.java
+++ b/src/core/gov/aps/jca/Version.java
@@ -155,14 +155,14 @@ public class Version {
         return implementationLanguage;
     }
 
-
     /**
      * 
      * @return version number
      */
-    private String getVersion() {
-		return version;
-	}
+    private String getVersion()
+    {
+        return version;
+    }
     /**
      * Major version number. This changes only when there is a
      * significant, externally apparent enhancement from the previous release.

--- a/src/core/gov/aps/jca/version.properties
+++ b/src/core/gov/aps/jca/version.properties
@@ -1,0 +1,1 @@
+jca.version=${project.version}


### PR DESCRIPTION
Removed the manually managed version numbers in the CAJContext and CAJServerContext.

Simplified the Version class to only support an automatically managed version string. Could not find any usage of the old Major, Minor,... fields. I have marked them as deprecated in case someone is still using Version class directly in their code.