### PR TITLE
CAS hook to allow building a CA name server

### DIFF
--- a/src/core/com/cosylab/epics/caj/cas/handlers/SearchResponse.java
+++ b/src/core/com/cosylab/epics/caj/cas/handlers/SearchResponse.java
@@ -90,7 +90,8 @@ public class SearchResponse extends AbstractCASResponseHandler {
 		}
 		
 		if (completion == ProcessVariableExistanceCompletion.EXISTS_HERE ||
-			completion == ProcessVariableExistanceCompletion.DOES_NOT_EXIST_HERE)
+			completion == ProcessVariableExistanceCompletion.DOES_NOT_EXIST_HERE ||
+			completion.doesExistElsewhere())
 		{
 			searchResponse(responseFrom, dataType, dataCount, parameter1, completion);
 		}
@@ -118,6 +119,18 @@ public class SearchResponse extends AbstractCASResponseHandler {
 			{
 				// TODO prepend version header (if context.getLastReceivedSequenceNumber() != 0)
 				SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), (short)dataCount, cid);
+				context.getBroadcastTransport().send(searchRequest, responseFrom);
+			} catch (Throwable th) {
+				context.getLogger().log(Level.WARNING, "Failed to send back search response to: " + responseFrom, th);
+			}
+		}
+		else if (completion.doesExistElsewhere())
+		{
+			// send back
+			try
+			{
+				// TODO prepend version header (if context.getLastReceivedSequenceNumber() != 0)
+				SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), completion.getOtherAddress(), (short)dataCount, cid);
 				context.getBroadcastTransport().send(searchRequest, responseFrom);
 			} catch (Throwable th) {
 				context.getLogger().log(Level.WARNING, "Failed to send back search response to: " + responseFrom, th);

--- a/src/core/gov/aps/jca/cas/ProcessVariableExistanceCompletion.java
+++ b/src/core/gov/aps/jca/cas/ProcessVariableExistanceCompletion.java
@@ -14,40 +14,70 @@
 
 package gov.aps.jca.cas;
 
-import gov.aps.jca.Enum;
+import java.net.InetSocketAddress;
 
 /**
- * Process variable existance completion enum class.
+ * Process variable existance completion class.
  * @author Matej Sekoranja (matej.sekoranja@cosylab.com)
- * @version $Id: ProcessVariableExistanceCompletion.java,v 1.1 2006-03-06 17:16:04 msekoranja Exp $
  */
-public final class ProcessVariableExistanceCompletion extends Enum
+public final class ProcessVariableExistanceCompletion
 {
-	   
+	private final String name;
+	private final InetSocketAddress addr;
+
 	/**
 	 * Process variable exists.
 	 */
-	public static final ProcessVariableExistanceCompletion EXISTS_HERE = new ProcessVariableExistanceCompletion("EXISTS_HERE");
+	public static final ProcessVariableExistanceCompletion EXISTS_HERE = new ProcessVariableExistanceCompletion("EXISTS_HERE", null);
+
+	/**
+	 * Process variable exists at a different address, not this CA server.
+	 */
+	public static ProcessVariableExistanceCompletion EXISTS_ELSEWHERE(final InetSocketAddress addr)
+	{
+		return new ProcessVariableExistanceCompletion("EXISTS_ELSEWHERE", addr);
+	}
+
+	/** @return Does the PV exist elsewhere? */
+	public boolean doesExistElsewhere()
+	{
+		return addr != null;
+	}
+
+	/** @return Other address where PV does exist or null */
+	public InetSocketAddress getOtherAddress()
+	{
+		return addr;
+	}
 
 	/**
 	 * Process variable does not exist.
 	 */
-	public static final ProcessVariableExistanceCompletion DOES_NOT_EXIST_HERE = new ProcessVariableExistanceCompletion("DOES_NOT_EXIST_HERE");
+	public static final ProcessVariableExistanceCompletion DOES_NOT_EXIST_HERE = new ProcessVariableExistanceCompletion("DOES_NOT_EXIST_HERE", null);
 
 	/**
 	 * Deffered result (asynchronous operation),
 	 * <code>ProcessVariableExistanceCompletionCallback.processVariableExistanceTestCompleted()</code> callback method method should be called to return completion.
 	 */
-	public static final ProcessVariableExistanceCompletion ASYNC_COMPLETION = new ProcessVariableExistanceCompletion("ASYNC_COMPLETION");
+	public static final ProcessVariableExistanceCompletion ASYNC_COMPLETION = new ProcessVariableExistanceCompletion("ASYNC_COMPLETION", null);
 
 	/**
 	 * Creates a new PV existance completion.
 	 * Contructor is <code>protected</code> to deny creation of unsupported types.
 	 * @param name	name of the completion.
+	 * @param addr  Address if exists elsewhere, otherwise null
 	 */
-	protected ProcessVariableExistanceCompletion(String name) {
-		super(name);
+	protected ProcessVariableExistanceCompletion(final String name, final InetSocketAddress addr) {
+		this.name = name;
+		this.addr = addr;
 	}
 
+	@Override
+	public String toString()
+	{
+		if (doesExistElsewhere())
+			return name + "@" + addr;
+		return name;
+	}
 
 }

--- a/test/com/cosylab/epics/caj/cas/test/CANameServer.java
+++ b/test/com/cosylab/epics/caj/cas/test/CANameServer.java
@@ -1,0 +1,93 @@
+package com.cosylab.epics.caj.cas.test;
+
+import java.net.InetSocketAddress;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.HashMap;
+import java.util.Map;
+import gov.aps.jca.CAException;
+import gov.aps.jca.CAStatus;
+import gov.aps.jca.CAStatusException;
+import gov.aps.jca.JCALibrary;
+import gov.aps.jca.cas.ProcessVariable;
+import gov.aps.jca.cas.ProcessVariableAttachCallback;
+import gov.aps.jca.cas.ProcessVariableEventCallback;
+import gov.aps.jca.cas.ProcessVariableExistanceCallback;
+import gov.aps.jca.cas.ProcessVariableExistanceCompletion;
+import gov.aps.jca.cas.Server;
+import gov.aps.jca.cas.ServerContext;
+
+/** Example for a Channel Access name server
+ * 
+ *  A name server is a CA server that listens to PV searches.
+ *  It does not, however, host any PVs.
+ *  Instead, it has a list of _other_ CA servers like IOCs
+ *  which host the PVs, and the CA name server then provides
+ *  the _other_ CA server's address.
+ * 
+ *  The main purpose is reduction of CA search traffic.
+ *  Instead of having clients broadcast their requests,
+ *  they can directly contact the CA name server.
+ * 
+ *  Example usage:
+ * 
+ *  In one terminal,
+ *  export EPICS_CA_SERVER_PORT=9876
+ *  then run an IOC database with a record named "ramp".
+ * 
+ *  In another terminal,
+ *  caget ramp
+ *  will not be able to connect.
+ * 
+ *  Now run this CANameServer on the same host,
+ *  and try `caget ramp` again.
+ *  It will reach the name server, which replies with 127.0.0.1, port 9876
+ *  to the seach request and client can then reach the IOC.
+ */
+public class CANameServer
+{
+    public static void main(String[] args) throws Exception
+    {   // Log as much as possible
+        final Logger logger = Logger.getLogger("");
+        logger.setLevel(Level.ALL);
+        for (Handler handler : logger.getHandlers())
+            handler.setLevel(Level.ALL);
+        
+        // Example for a name server database using some hardcoded values.
+        final Map<String, InetSocketAddress> names = new HashMap<>();
+        names.put("ramp", new InetSocketAddress("127.0.0.1", 9876));
+        names.put("Fred", new InetSocketAddress("1.2.3.4", 4242));
+        names.put("Jane", new InetSocketAddress("5.6.7.8", 5757));
+                
+        JCALibrary jca = JCALibrary.getInstance();        
+        Server server = new Server()
+        {
+            @Override
+            public ProcessVariableExistanceCompletion processVariableExistanceTest(String name,
+                                                                                   InetSocketAddress client,
+                                                                                   ProcessVariableExistanceCallback callback)
+                    throws CAException, IllegalArgumentException, IllegalStateException
+            {
+                System.out.println("Client " + client + " searches for '" + name + "'");
+                final InetSocketAddress addr = names.get(name);
+                if (addr != null)
+                    return ProcessVariableExistanceCompletion.EXISTS_ELSEWHERE(addr);
+                else
+                    return ProcessVariableExistanceCompletion.DOES_NOT_EXIST_HERE;
+            }
+
+            @Override
+            public ProcessVariable processVariableAttach(String name,
+                                                         ProcessVariableEventCallback event,
+                                                         ProcessVariableAttachCallback attach)
+                    throws CAStatusException, IllegalArgumentException, IllegalStateException
+            {
+                throw new CAStatusException(CAStatus.NOSUPPORT, "not supported");
+            }
+        };
+        
+        final ServerContext context = jca.createServerContext(JCALibrary.CHANNEL_ACCESS_SERVER_JAVA, server);
+        context.run(0);
+    }
+}


### PR DESCRIPTION
This extends the `ProcessVariableExistanceCompletion` used in the CA server to not only support `EXISTS_HERE` but also a new option `EXISTS_ELSEWHERE(InetSocketAddress)`.

This allows implementing a name server which listens to search requests and replies to clients with the IP address and TCP port of the CA server that actually hosts a PV.

Technically, the `ProcessVariableExistanceCompletion` was changed from an `Enum` to a class with some static members, but it was done in such that all existing demos still compile without changes because they never used the `Enum` functionality.

Also added is a CA name server demo that replies with some statically coded PV addresses.