### PR TITLE
CA server (and thus name server demo) now support searches via TCP

### DIFF
--- a/src/core/com/cosylab/epics/caj/cas/handlers/SearchResponse.java
+++ b/src/core/com/cosylab/epics/caj/cas/handlers/SearchResponse.java
@@ -138,14 +138,16 @@ public class SearchResponse extends AbstractCASResponseHandler {
 			try
 			{
 				// TODO prepend version header (if context.getLastReceivedSequenceNumber() != 0)
-				SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), (short)dataCount, cid);
+				// UDP includes payload (version) in reply, TCP has no payload
 				if (tcp == null)
 				{
+					SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), null, true, (short)dataCount, cid);
 					context.getLogger().log(Level.FINE, "UDP EXISTS_HERE search reply");
 					context.getBroadcastTransport().send(searchRequest, responseFrom);
 				}
 				else
 				{
+					SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), null, false, (short)dataCount, cid);
 					context.getLogger().log(Level.FINE, "TCP EXISTS_HERE search reply");
 				    tcp.send(searchRequest.getRequestMessage());
 				}
@@ -155,18 +157,18 @@ public class SearchResponse extends AbstractCASResponseHandler {
 		}
 		else if (completion.doesExistElsewhere())
 		{
-			// send back
+			// Same comments as for EXISTS_HERE
 			try
 			{
-				// TODO prepend version header (if context.getLastReceivedSequenceNumber() != 0)
-				SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), completion.getOtherAddress(), (short)dataCount, cid);
 				if (tcp == null)
 				{
+					SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), completion.getOtherAddress(), true, (short)dataCount, cid);
 					context.getLogger().log(Level.FINE, "UDP EXISTS_ELSEWHERE search reply: " + completion.getOtherAddress());
 					context.getBroadcastTransport().send(searchRequest, responseFrom);
 				}
 				else
 				{
+					SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), completion.getOtherAddress(), false, (short)dataCount, cid);
 					context.getLogger().log(Level.FINE, "TCP EXISTS_ELSEWHERE search reply: " + completion.getOtherAddress());
 				    tcp.send(searchRequest.getRequestMessage());
 				}

--- a/src/core/com/cosylab/epics/caj/cas/handlers/SearchResponse.java
+++ b/src/core/com/cosylab/epics/caj/cas/handlers/SearchResponse.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.logging.Level;
 
 import com.cosylab.epics.caj.cas.CAJServerContext;
+import com.cosylab.epics.caj.cas.CASTransport;
 import com.cosylab.epics.caj.cas.requests.SearchFailedRequest;
 import com.cosylab.epics.caj.cas.requests.SearchRequest;
 import com.cosylab.epics.caj.impl.CAConstants;
@@ -49,12 +50,29 @@ public class SearchResponse extends AbstractCASResponseHandler {
 		Transport transport,
 		ByteBuffer[] response) {
 
-		ByteBuffer headerBuffer = response[0];
-		final int start = headerBuffer.position();
+		// For a UDP client, BroadcastTransport.processRead will call this with response=[buffer].
+		// That one buffer holds version info, search header and search payload, positioned at start of payload:
+        //
+		// 00 00 00 00  00 01 00 0D  00 00 00 01  00 00 00 00  .... .... .... .... 
+		// 00 06 00 08  00 05 00 0D  00 00 00 01  00 00 00 01  .... .... .... .... 
+		// 54 45 53 54  00 00 00 00                            TEST .... 
+		// ^^
+        //
+		// For a TCP client, CASTransport.processRead will call this with a response=[headerBuffer, payloadBuffer].
+		// headerBuffer is positioned at the end, and a payloadBuffer positioned at the start:
+        //
+		// 00 06 00 08  00 05 00 0D  00 00 00 01  00 00 00 01  .... .... .... .... 
+        //                                                   ^^
+		// 54 45 53 54  00 00 00 00                            TEST .... 
+        // ^^
+		// We need the payload, which holds the zero-padded channel name
+		ByteBuffer buffer = response.length == 2 ? response[1] : response[0];
+
+		final int start = buffer.position();
 		final int bufferEnd = start + payloadSize;
 
 		// to support multiple messages in one UDP packet
-		headerBuffer.position(bufferEnd);
+		buffer.position(bufferEnd);
 
 		// check channel name size
 		if (payloadSize <= 1) {
@@ -62,7 +80,7 @@ public class SearchResponse extends AbstractCASResponseHandler {
 			return;
 		}
 
-		String channelName = extractString(headerBuffer, start, payloadSize, false);
+		String channelName = extractString(buffer, start, payloadSize, false);
 		
 		// empty name check
 		if (channelName.length() == 0) {
@@ -92,8 +110,9 @@ public class SearchResponse extends AbstractCASResponseHandler {
 		if (completion == ProcessVariableExistanceCompletion.EXISTS_HERE ||
 			completion == ProcessVariableExistanceCompletion.DOES_NOT_EXIST_HERE ||
 			completion.doesExistElsewhere())
-		{
-			searchResponse(responseFrom, dataType, dataCount, parameter1, completion);
+		{	// Reply via TCP?
+			CASTransport tcp = transport instanceof CASTransport ? (CASTransport) transport : null;
+			searchResponse(responseFrom, tcp, dataType, dataCount, parameter1, completion);
 		}
 		// in case of ProcessVariableExistanceCompletion.ASYNC_COMPLETION callback will call searchResponse method
 		// in case of null, do nothing
@@ -102,12 +121,13 @@ public class SearchResponse extends AbstractCASResponseHandler {
 	/**
 	 * Respond to search response.
 	 * @param responseFrom
+	 * @param tcp Use TCP CASTransport?
 	 * @param dataType
 	 * @param dataCount
 	 * @param cid
 	 * @param completion
 	 */
-	private void searchResponse(InetSocketAddress responseFrom, short dataType, int dataCount, int cid, ProcessVariableExistanceCompletion completion) {
+	private void searchResponse(InetSocketAddress responseFrom, CASTransport tcp, short dataType, int dataCount, int cid, ProcessVariableExistanceCompletion completion) {
 
 		//
 		// ... respond
@@ -119,7 +139,16 @@ public class SearchResponse extends AbstractCASResponseHandler {
 			{
 				// TODO prepend version header (if context.getLastReceivedSequenceNumber() != 0)
 				SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), (short)dataCount, cid);
-				context.getBroadcastTransport().send(searchRequest, responseFrom);
+				if (tcp == null)
+				{
+					context.getLogger().log(Level.FINE, "UDP EXISTS_HERE search reply");
+					context.getBroadcastTransport().send(searchRequest, responseFrom);
+				}
+				else
+				{
+					context.getLogger().log(Level.FINE, "TCP EXISTS_HERE search reply");
+				    tcp.send(searchRequest.getRequestMessage());
+				}
 			} catch (Throwable th) {
 				context.getLogger().log(Level.WARNING, "Failed to send back search response to: " + responseFrom, th);
 			}
@@ -131,7 +160,16 @@ public class SearchResponse extends AbstractCASResponseHandler {
 			{
 				// TODO prepend version header (if context.getLastReceivedSequenceNumber() != 0)
 				SearchRequest searchRequest = new SearchRequest(context.getBroadcastTransport(), completion.getOtherAddress(), (short)dataCount, cid);
-				context.getBroadcastTransport().send(searchRequest, responseFrom);
+				if (tcp == null)
+				{
+					context.getLogger().log(Level.FINE, "UDP EXISTS_ELSEWHERE search reply: " + completion.getOtherAddress());
+					context.getBroadcastTransport().send(searchRequest, responseFrom);
+				}
+				else
+				{
+					context.getLogger().log(Level.FINE, "TCP EXISTS_ELSEWHERE search reply: " + completion.getOtherAddress());
+				    tcp.send(searchRequest.getRequestMessage());
+				}
 			} catch (Throwable th) {
 				context.getLogger().log(Level.WARNING, "Failed to send back search response to: " + responseFrom, th);
 			}
@@ -197,7 +235,7 @@ public class SearchResponse extends AbstractCASResponseHandler {
 		 * @see gov.aps.jca.cas.ProcessVariableExistanceCallback#processVariableExistanceTestCompleted(gov.aps.jca.cas.ProcessVariableExistanceCompletion)
 		 */
 		public void processVariableExistanceTestCompleted(ProcessVariableExistanceCompletion completion) {
-			searchResponse(responseFrom, dataType, dataCount, cid, completion);
+			searchResponse(responseFrom, null /* not TCP */, dataType, dataCount, cid, completion);
 		}
 
 		/* (non-Javadoc)

--- a/src/core/com/cosylab/epics/caj/cas/handlers/VersionResponse.java
+++ b/src/core/com/cosylab/epics/caj/cas/handlers/VersionResponse.java
@@ -14,12 +14,15 @@
 
 package com.cosylab.epics.caj.cas.handlers;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
 import com.cosylab.epics.caj.cas.CAJServerContext;
 import com.cosylab.epics.caj.cas.CASTransport;
 import com.cosylab.epics.caj.impl.Transport;
+import com.cosylab.epics.caj.impl.CAConstants;
 
 /**
  * Version (request) handler.
@@ -60,6 +63,26 @@ public class VersionResponse extends AbstractCASResponseHandler {
 		{
 			// TCP only
 			((CASTransport)transport).setPriority(dataType);
+
+			// By responding to client with version info we indicate support for TCP name search
+			// https://docs.epics-controls.org/en/latest/internal/ca_protocol.html#tcp-search
+			// "CA_PROTO_SEARCH messages MUST NOT be sent on a Circuit unless a CA_PROTO_VERSION message has been received indicating >= CA_V412."
+
+			ByteBuffer my_response = ByteBuffer.allocate(16);
+			my_response.putShort((short)0); // Command: Version
+			my_response.putShort((short)0); // Payload Size: nothing
+			my_response.putShort((short)0); // Priority
+			my_response.putShort(CAConstants.CA_MINOR_PROTOCOL_REVISION);
+			my_response.putInt(0);          // Reserved parameter 1
+			my_response.putInt(0);          // Reserved parameter 2
+			try
+			{
+				((CASTransport)transport).send(my_response);
+			}
+			catch (Exception ex)
+			{
+				Logger.global.log(Level.WARNING, "Server cannot send version response", ex);
+			}
 		}
 	}
 

--- a/src/core/com/cosylab/epics/caj/impl/BroadcastTransport.java
+++ b/src/core/com/cosylab/epics/caj/impl/BroadcastTransport.java
@@ -237,6 +237,9 @@ public class BroadcastTransport implements Transport, ReactorHandler {
 	 */
 	protected void send(ByteBuffer buffer) 
 	{
+		// TCP-only search?
+		if (broadcastAddresses == null)
+			return;
 		for (int i = 0; i < broadcastAddresses.length; i++)
 		{
 			try

--- a/test/com/cosylab/epics/caj/cas/test/CANameServer.java
+++ b/test/com/cosylab/epics/caj/cas/test/CANameServer.java
@@ -33,17 +33,24 @@ import gov.aps.jca.cas.ServerContext;
  *  Example usage:
  * 
  *  In one terminal,
- *  export EPICS_CA_SERVER_PORT=9876
+ *      export EPICS_CA_SERVER_PORT=9876
  *  then run an IOC database with a record named "ramp".
  * 
- *  In another terminal,
- *  caget ramp
- *  will not be able to connect.
+ *  In another terminal, check that
+ *      caget ramp
+ *  will NOT be able to connect because it searches by default
+ *  via UDP port 5064, while the IOC runs on 9876 (UDP and TCP).
  * 
  *  Now run this CANameServer on the same host,
  *  and try `caget ramp` again.
- *  It will reach the name server, which replies with 127.0.0.1, port 9876
- *  to the seach request and client can then reach the IOC.
+ *  The client will reach the name server via UDP 5064.
+ *  The name server replies with 127.0.0.1, port 9876
+ *  to the search request and client can then reach the IOC.
+ * 
+ *  The CANameServer also supports searches via TCP:
+ *      export EPICS_CA_NAME_SERVERS=127.0.0.1
+ *      export EPICS_CA_AUTO_ADDR_LIST=no
+ *      caget ramp
  */
 public class CANameServer
 {

--- a/test/com/cosylab/epics/caj/cas/test/CANameServer.java
+++ b/test/com/cosylab/epics/caj/cas/test/CANameServer.java
@@ -32,9 +32,10 @@ import gov.aps.jca.cas.ServerContext;
  * 
  *  Example usage:
  * 
- *  In one terminal,
+ *  In one terminal, run an IOC database with a record named "ramp"
+ *  under a non-default UDP and TCP port:
  *      export EPICS_CA_SERVER_PORT=9876
- *  then run an IOC database with a record named "ramp".
+ *      softIoc -d test/resources/ramp.db 
  * 
  *  In another terminal, check that
  *      caget ramp

--- a/test/com/cosylab/epics/caj/cas/test/CANameServer.java
+++ b/test/com/cosylab/epics/caj/cas/test/CANameServer.java
@@ -42,6 +42,7 @@ import gov.aps.jca.cas.ServerContext;
  *  via UDP port 5064, while the IOC runs on 9876 (UDP and TCP).
  * 
  *  Now run this CANameServer on the same host,
+ *      java -cp target/classes:target/test-classes -DCAJ_DEBUG=true com.cosylab.epics.caj.cas.test.CANameServer
  *  and try `caget ramp` again.
  *  The client will reach the name server via UDP 5064.
  *  The name server replies with 127.0.0.1, port 9876

--- a/test/com/cosylab/epics/caj/test/caget.java
+++ b/test/com/cosylab/epics/caj/test/caget.java
@@ -1,0 +1,48 @@
+package com.cosylab.epics.caj.test;
+
+import gov.aps.jca.JCALibrary;
+import gov.aps.jca.Context;
+import com.cosylab.epics.caj.CAJContext;
+import gov.aps.jca.Channel;
+import gov.aps.jca.dbr.DBR;
+import gov.aps.jca.dbr.DBRType;
+import gov.aps.jca.dbr.DBR_Double;
+
+/** Bad but simple 'caget' demo
+ *  Better implementation would use listeners
+ *  instead of fixed wait times,
+ *  handle all data types,
+ *  and properly close channel and context.
+ * 
+ *  Example invocation:
+ *  java -cp target/classes:target/test-classes -DCAJ_DEBUG=true -Djca.use_env=true com.cosylab.epics.caj.test.caget PV_name
+ */
+public class caget
+{
+    public static void main(String[] args) throws Exception
+    {
+        if (args.length != 1)
+        {
+            System.err.println("USAGE: caget PV_name");
+            System.exit(1);
+        }
+        final String name = args[0];
+
+        final JCALibrary jca = JCALibrary.getInstance();
+        final Context context = new CAJContext();
+        final Channel channel = context.createChannel(name);
+        context.pendIO(2.0);
+        
+        DBR data = channel.get(DBRType.DOUBLE, 1);
+        context.pendIO(2.0);
+
+        if (data instanceof DBR_Double)
+        {
+            DBR_Double value = (DBR_Double) data;
+            System.out.println(name + " = " + value.getDoubleValue()[0]);
+        }
+        else
+            System.out.println(data);
+        System.exit(0);
+    }
+}

--- a/test/resources/ramp.db
+++ b/test/resources/ramp.db
@@ -1,0 +1,6 @@
+record(calc, "ramp")
+{
+  field(SCAN, "1 second")
+  field(CALC, "A+1")
+  field(INPA, "ramp")
+}


### PR DESCRIPTION
When adding a hook to enable implementation of a name server, #80, it was noted that the CAJ server code doesn't support searches via TCP, which is desirable for a name server.

While the code seemed to support TCP name searches at first glance, a few details were missing.
The server needs to send a “version” message. Clients will only perform a TCP search after at least minor version 12 has been indicated.
When the server receives a search via TCP, it needs to respond via that same TCP channel, not UDP, duh.
In the search response, the server should skip the “minor version” payload because that has already been communicated in the initial “version” message. At least that's what the C/C++ server does.
The client, on the other hand, should not crash when the (older) CAJ server does include the  “minor version” payload in TCP reply.
Now the CAJ server behaves like the one in the IOC, and the CAJ client can handle search replies both "with" and "without" payload.

Tested server (Java BasicExample, Java Name Server, C/C++ IOC) and clients (caget from base, simple CAJ caget) and all combinations seem to communicate.
